### PR TITLE
Trying to deal with co-located pars and fixing some add_obs issues

### DIFF
--- a/autotest/pst_from_tests.py
+++ b/autotest/pst_from_tests.py
@@ -238,6 +238,12 @@ def freyberg_prior_build_test():
             [0, 0, 1, m.dis.top.array[0, 1], 1.0, m.dis.botm.array[0, 0, 1]],
             [0, 0, 1, m.dis.top.array[0, 1], 1.0, m.dis.botm.array[0, 0, 1]]]})
 
+    welsp = m.wel.stress_period_data.data.copy()
+    addwell = welsp[0].copy()
+    addwell['k'] = 1
+    welsp[0] = np.rec.array(np.concatenate([welsp[0], addwell]))
+    m.wel.stress_period_data = welsp
+
     org_model_ws = "temp_pst_from"
     if os.path.exists(org_model_ws):
         shutil.rmtree(org_model_ws)

--- a/autotest/pst_from_tests.py
+++ b/autotest/pst_from_tests.py
@@ -86,8 +86,8 @@ def freyberg_test():
                       "Processed into tabular form using the lines:\n",
                       "sfo = flopy.utils.SfrFile('freyberg.sfr.out')\n",
                       "sfo.get_dataframe().to_csv('freyberg.sfo.dat')\n"])
-        sfodf.to_csv(fp, sep=' ', index_label='idx')
-    sfodf.to_csv(os.path.join(m.model_ws, 'freyberg.sfo.csv'),
+        sfodf.sort_index(1).to_csv(fp, sep=' ', index_label='idx')
+    sfodf.sort_index(1).to_csv(os.path.join(m.model_ws, 'freyberg.sfo.csv'),
                  index_label='idx')
     template_ws = "new_temp"
     # sr0 = m.sr
@@ -111,7 +111,7 @@ def freyberg_test():
     # sfr outputs to obs
     pf.add_observations('freyberg.sfo.dat', insfile=None,
                         index_cols=['segment', 'reach', 'kstp', 'kper'],
-                        use_cols=["Qaquifer", "Qout"], prefix='sfr',
+                        use_cols=["Qaquifer", "Qout", 'width'], prefix='sfr',
                         ofile_skip=4, ofile_sep=' ')
     pf.tmp_files.append(f"{m.name}.sfr.out")
     pf.extra_py_imports.append('flopy')
@@ -126,17 +126,17 @@ def freyberg_test():
          "'Processed into tabular form using the lines:\\n', "
          "'sfo = flopy.utils.SfrFile(`freyberg.sfr.out`)\\n', "
          "'sfo.get_dataframe().to_csv(`freyberg.sfo.dat`)\\n'])",
-         "    sfodf.to_csv(fp, sep=' ', index_label='idx')"])
+         "    sfodf.sort_index(1).to_csv(fp, sep=' ', index_label='idx')"])
     # csv version of sfr obs
     # sfr outputs to obs
     pf.add_observations('freyberg.sfo.csv', insfile=None,
                         index_cols=['segment', 'reach', 'kstp', 'kper'],
-                        use_cols=["Qaquifer", "Qout"], prefix='sfr2',
-                        ofile_sep=',', obsgp=['qaquifer', 'qout'])
+                        use_cols=["Qaquifer", "Qout", "width"], prefix='sfr2',
+                        ofile_sep=',', obsgp=['qaquifer', 'qout', "width"])
     obsnmes = pd.concat([df.obgnme for df in pf.obs_dfs]).unique()
     assert all([gp in obsnmes for gp in ['qaquifer', 'qout']])
     pf.post_py_cmds.append(
-        "sfodf.to_csv('freyberg.sfo.csv', sep=',', index_label='idx')")
+        "sfodf.sort_index(1).to_csv('freyberg.sfo.csv', sep=',', index_label='idx')")
 
     # pars
     pf.add_parameters(filenames="RIV_0000.dat", par_type="grid",
@@ -242,6 +242,9 @@ def freyberg_prior_build_test():
     addwell = welsp[0].copy()
     addwell['k'] = 1
     welsp[0] = np.rec.array(np.concatenate([welsp[0], addwell]))
+    samewell = welsp[1].copy()
+    samewell['flux'] *= 10
+    welsp[1] = np.rec.array(np.concatenate([welsp[1], samewell]))
     m.wel.stress_period_data = welsp
 
     org_model_ws = "temp_pst_from"

--- a/pyemu/prototypes/pst_from.py
+++ b/pyemu/prototypes/pst_from.py
@@ -1,4 +1,3 @@
-
 from __future__ import print_function, division
 import os
 from datetime import datetime
@@ -18,7 +17,7 @@ def _get_datetime_from_str(sdt):
     # could be expanded if someone is feeling clever.
     if isinstance(sdt, str):
         PyemuWarning("Assuming passed reference start date time is "
-                         "year first str {0}".format(sdt))
+                     "year first str {0}".format(sdt))
         sdt = pd.to_datetime(sdt, yearfirst=True)
     assert isinstance(sdt, pd.Timestamp), ("Error interpreting start_datetime")
     return sdt
@@ -51,6 +50,7 @@ class PstFrom(object):
         zero_based:
         start_datetime:
     """
+
     # TODO: doc strings!!!
     def __init__(self, original_d, new_d, longnames=True,
                  remove_existing=False, spatial_reference=None,
@@ -196,7 +196,7 @@ class PstFrom(object):
 
     def _flopy_mg_get_xy(self, args, **kwargs):
         i, j = self.parse_kij_args(args, kwargs)
-        if all([ij is None for ij in [i,j]]):
+        if all([ij is None for ij in [i, j]]):
             return i, j
         else:
             return (self._spatial_reference.xcellcenters[i, j],
@@ -245,7 +245,7 @@ class PstFrom(object):
             if ilist is None:
                 continue
 
-            if not isinstance(ilist,list):
+            if not isinstance(ilist, list):
                 ilist = [ilist]
             for cmd in ilist:
                 self.logger.statement("forward_run line:{0}".format(cmd))
@@ -290,7 +290,7 @@ class PstFrom(object):
                 par_dfs.append(df)
             struct_dict[gs] = par_dfs
         return struct_dict
-    
+
     def build_prior(self, fmt="ascii", filename=None, droptol=None, chunk=None,
                     sigma_range=6):
         """
@@ -592,7 +592,7 @@ class PstFrom(object):
                                 self.logger.warn("Detected mid-table comment "
                                                  "on line {0} tabular model file, "
                                                  "comment will be lost"
-                                                 "".format(key+1))
+                                                 "".format(key + 1))
                                 lc += 1
                                 continue
                                 # TODO if we want to preserve mid-table comments,
@@ -624,14 +624,14 @@ class PstFrom(object):
             # check for compatibility
             fnames = list(file_dict.keys())
             for i in range(len(fnames)):
-                for j in range(i+1, len(fnames)):
+                for j in range(i + 1, len(fnames)):
                     if (file_dict[fnames[i]].shape[1] !=
                             file_dict[fnames[j]].shape[1]):
                         self.logger.lraise(
                             "shape mismatch for array types, '{0}' "
                             "shape {1} != '{2}' shape {3}".
-                            format(fnames[i], file_dict[fnames[i]].shape[1],
-                                   fnames[j], file_dict[fnames[j]].shape[1]))
+                                format(fnames[i], file_dict[fnames[i]].shape[1],
+                                       fnames[j], file_dict[fnames[j]].shape[1]))
         else:  # load array type files
             # loop over model input files
             for filename, sep, fmt, skip in zip(filenames, seps, fmts,
@@ -664,7 +664,7 @@ class PstFrom(object):
             # check for compatibility
             fnames = list(file_dict.keys())
             for i in range(len(fnames)):
-                for j in range(i+1, len(fnames)):
+                for j in range(i + 1, len(fnames)):
                     if (file_dict[fnames[i]].shape !=
                             file_dict[fnames[j]].shape):
                         self.logger.lraise(
@@ -674,7 +674,7 @@ class PstFrom(object):
                                       fnames[j], file_dict[fnames[j]].shape))
         return index_cols, use_cols, file_dict, fmt_dict, sep_dict, skip_dict
 
-    def _next_count(self,prefix):
+    def _next_count(self, prefix):
         if prefix not in self._prefix_count:
             self._prefix_count[prefix] = 0
         else:
@@ -836,7 +836,7 @@ class PstFrom(object):
             self.logger.lraise(
                 "the following obs instruction file {0} are already in the "
                 "control file:{1}".
-                format(ins_file, ','.join(sint)))
+                    format(ins_file, ','.join(sint)))
 
         # find "new" obs that are not already in the control file
         new_obsnme = sobsnme - sexist
@@ -996,6 +996,10 @@ class PstFrom(object):
             if all(xy in keys for xy in ['x', 'y']):
                 o_idx = np.argsort(keys)
                 xy_in_idx = o_idx[np.searchsorted(keys[o_idx], ['x', 'y'])]
+            else:
+                self.logger.lraise("If passing `index_cols` as type == dict, "
+                                   "keys need to contain [`i` and `j`] or "
+                                   "[`x` and `y`]")
 
         (index_cols, use_cols, file_dict,
          fmt_dict, sep_dict, skip_dict) = self._par_prep(
@@ -1082,8 +1086,8 @@ class PstFrom(object):
                 "Parameter dataframe wrong shape for number of cols {0}"
                 "".format(use_cols))
             # variables need to be passed to each row in df
-            lower_bound = np.tile(lower_bound, int(len(df)/ncol))
-            upper_bound = np.tile(upper_bound, int(len(df)/ncol))
+            lower_bound = np.tile(lower_bound, int(len(df) / ncol))
+            upper_bound = np.tile(upper_bound, int(len(df) / ncol))
             self.logger.log(
                 "writing list-based template file '{0}'".format(tpl_filename))
         else:  # Assume array type parameter file
@@ -1285,7 +1289,7 @@ class PstFrom(object):
         df.loc[:, "partrans"] = transform
         df.loc[:, "parubnd"] = upper_bound
         df.loc[:, "parlbnd"] = lower_bound
-        #df.loc[:,"tpl_filename"] = tpl_filename
+        # df.loc[:,"tpl_filename"] = tpl_filename
 
         # store tpl --> in filename pair
         self.tpl_filenames.append(tpl_filename)
@@ -1312,7 +1316,10 @@ class PstFrom(object):
         # TODO maybe use different marker to denote a relationship between pars
         #  at the moment relating pars using common geostruct and pargp but may
         #  want to reserve pargp for just PEST
-        gp_dict = {g: [d] for g, d in df.groupby('pargp')}
+        if 'covgp' not in df.columns:
+            gp_dict = {g: [d] for g, d in df.groupby('pargp')}
+        else:
+            gp_dict = {g: [d] for g, d in df.groupby('covgp')}
         # df_list = [d for g, d in df.groupby('pargp')]
         if geostruct is not None:
             # relating pars to geostruct....
@@ -1330,7 +1337,7 @@ class PstFrom(object):
                         # update dict entry with new {key:par} pair
                         self.par_struct_dict[geostruct].update({gp: gppars})
                     else:
-                        # if pargp already assigned to this geostruct append par
+                        # if gp already assigned to this geostruct append par
                         # list to approprate group key
                         self.par_struct_dict[geostruct][gp].extend(gppars)
                 # self.par_struct_dict_l[geostruct].extend(list(gp_dict.values()))
@@ -1586,7 +1593,9 @@ def write_list_tpl(dfs, name, tpl_filename, index_cols, par_type,
         longnames (`boolean`): Specify is pars will be specified without the
             12 char restriction - recommended if using Pest++.
         get_xy (`pyemu.PstFrom` method): Can be specified to get real-world xy
-            from `index_cols` passed (to include in par name)
+            from `index_cols` passed (to assist correlation definition)
+        ij_in_idx (`list` or `array`): defining which `index_cols` contain i,j
+        xy_in_idx (`list` or `array`): defining which `index_cols` contain x,y
         zero_based (`boolean`): IMPORTANT - pass as False if `index_cols`
             are NOT zero-based indicies (e.g. MODFLOW row/cols).
             If False 1 with be subtracted from `index_cols`.
@@ -1595,18 +1604,66 @@ def write_list_tpl(dfs, name, tpl_filename, index_cols, par_type,
     Returns:
 
     """
-    # get dataframe with autogenerated parnames based on `name`, `indx_cols`,
+    # get dataframe with autogenerated parnames based on `name`, `index_cols`,
     # `use_cols`, `suffix` and `par_type`
     df_tpl = _get_tpl_or_ins_df(dfs, name, index_cols, par_type,
                                 use_cols=use_cols, suffix=suffix, gpname=gpname,
                                 zone_array=zone_array, longnames=longnames,
                                 get_xy=get_xy, ij_in_idx=ij_in_idx,
                                 xy_in_idx=xy_in_idx, zero_based=zero_based)
+
+    for col in use_cols:  # corellations flagged using pargp
+        df_tpl["covgp{0}".format(col)] = df_tpl.loc[:,
+                                         "pargp{0}".format(col)].values
+    # needs modifying if colocated pars in same group
+    if par_type == 'grid' and 'x' in df_tpl.columns:
+        if df_tpl.duplicated(['x', 'y']).any():
+            # may need to use a different grouping for parameter correlations
+            # where parameter x and y values are the same but pars are not
+            # correlated (e.g. 2d correlation but different layers)
+            # - this will only work if `index_cols` contains a third dimension.
+            if len(index_cols) > 2:
+                third_d = index_cols.copy()
+                if xy_in_idx is not None:
+                    for idx in xy_in_idx:
+                        third_d.pop(idx)
+                elif ij_in_idx is not None:
+                    for idx in ij_in_idx:
+                        third_d.pop(idx)
+                else:  # if xy_in_idx and ij_in_idx ar None
+                    # then parse_kij assumes that i is at idx[-2] and j at idx[-1]
+                    third_d.pop()  # pops -1
+                    third_d.pop()  # pops -2
+                PyemuWarning("Coincidently located pars in list-like file, "
+                             "attempting to separate pars based on `index_cols` "
+                             "passed - using index_col[{0}] for third dimension"
+                             "".format(third_d[-1]))
+                for col in use_cols:
+                    df_tpl["covgp{0}".format(col)
+                    ] = df_tpl.loc[:, "covgp{0}".format(col)
+                        ].str.cat(
+                        pd.DataFrame(
+                            df_tpl.sidx.to_list()).iloc[:, 0].astype(str),
+                        '_cov')
+            else:
+                PyemuWarning("Coincidently located pars in list-like file. "
+                             "Likely to cause issues building par cov or "
+                             "drawing par ensemble. Can be resolved by passing "
+                             "an additional `index_col` as a basis for "
+                             "splitting colocated correlations (e.g. Layer)")
+    # pull out par details where multiple `use_cols` are requested
     parnme = list(df_tpl.loc[:, use_cols].values.flatten())
     pargp = list(
         df_tpl.loc[:, ["pargp{0}".format(col)
                        for col in use_cols]].values.flatten())
-    df_par = pd.DataFrame({"parnme": parnme, "pargp": pargp}, index=parnme)
+    covgp = list(
+        df_tpl.loc[:, ["covgp{0}".format(col)
+                       for col in use_cols]].values.flatten())
+    df_tpl = df_tpl.drop([
+        col for col in df_tpl.columns if str(col).startswith('covgp')], axis=1)
+    df_par = pd.DataFrame({"parnme": parnme, "pargp": pargp, 'covgp': covgp},
+                          index=parnme)
+
     if par_type == 'grid' and 'x' in df_tpl.columns:  # TODO work out if x,y needed for constant and zone pars too
         df_par['x'], df_par['y'] = np.concatenate(
             df_tpl.apply(lambda r: [[r.x, r.y] for _ in use_cols],
@@ -1663,6 +1720,8 @@ def _get_tpl_or_ins_df(dfs, name, index_cols, typ, use_cols=None,
             20/12 char restriction - recommended if using Pest++.
         get_xy (`pyemu.PstFrom` method): Can be specified to get real-world xy
             from `index_cols` passed (to include in obs/par name)
+        ij_in_idx (`list` or `array`): defining which `index_cols` contain i,j
+        xy_in_idx (`list` or `array`): defining which `index_cols` contain x,y
         zero_based (`boolean`): IMPORTANT - pass as False if `index_cols`
             are NOT zero-based indicies (e.g. MODFLOW row/cols).
             If False 1 with be subtracted from `index_cols`.
@@ -1726,8 +1785,6 @@ def _get_tpl_or_ins_df(dfs, name, index_cols, typ, use_cols=None,
             df_ti[['x', 'y']] = pd.DataFrame(
                 df_ti.sidx.to_list()).iloc[:, xy_in_idx]
         else:
-            # TODO need to be more flexible with index_cols
-            #   cant just assume index_cols will be k,i,j (if 3) and i,j (if 2)
             df_ti.loc[:, 'xy'] = df_ti.sidx.apply(get_xy, ij_id=ij_in_idx)
             df_ti.loc[:, 'x'] = df_ti.xy.apply(lambda x: x[0])
             df_ti.loc[:, 'y'] = df_ti.xy.apply(lambda x: x[1])
@@ -1944,5 +2001,3 @@ def write_array_tpl(name, tpl_filename, suffix, par_type, zone_array=None,
         np.savetxt(input_filename, arr, fmt="%2.1f")
 
     return df
-
-

--- a/pyemu/prototypes/pst_from.py
+++ b/pyemu/prototypes/pst_from.py
@@ -230,7 +230,7 @@ class PstFrom(object):
               hasattr(self._spatial_reference, "ycellcenters")):
             # support modelgrid style cell locs
             self._spatial_reference.xcentergrid = self._spatial_reference.xcellcenters
-            self._spatial_reference.xcentergrid = self._spatial_reference.xcellcenters
+            self._spatial_reference.ycentergrid = self._spatial_reference.ycellcenters
             self.get_xy = self._flopy_mg_get_xy
         else:
             self.logger.lraise("initialize_spatial_reference() error: "
@@ -443,7 +443,7 @@ class PstFrom(object):
             if update is True:
                 update = {'pars': False, 'obs': False}
             elif isinstance(update, str):
-                update = {str: True}
+                update = {update: True}
             elif isinstance(update, (set, list)):
                 update = {s: True for s in update}
             uupdate = True

--- a/pyemu/prototypes/pst_from.py
+++ b/pyemu/prototypes/pst_from.py
@@ -990,12 +990,14 @@ class PstFrom(object):
             # TODO: or datetime str?
             keys = np.array([k.lower() for k in index_cols.keys()])
             idx_cols = [index_cols[k] for k in keys]
-            if all(ij in keys for ij in ['i', 'j']):
-                o_idx = np.argsort(keys)
-                ij_in_idx = o_idx[np.searchsorted(keys[o_idx], ['i', 'j'])]
-            if all(xy in keys for xy in ['x', 'y']):
-                o_idx = np.argsort(keys)
-                xy_in_idx = o_idx[np.searchsorted(keys[o_idx], ['x', 'y'])]
+            if any(all(a in keys for a in aa)
+                   for aa in [['i', 'j'], ['x', 'y']]):
+                if all(ij in keys for ij in ['i', 'j']):
+                    o_idx = np.argsort(keys)
+                    ij_in_idx = o_idx[np.searchsorted(keys[o_idx], ['i', 'j'])]
+                if all(xy in keys for xy in ['x', 'y']):
+                    o_idx = np.argsort(keys)
+                    xy_in_idx = o_idx[np.searchsorted(keys[o_idx], ['x', 'y'])]
             else:
                 self.logger.lraise("If passing `index_cols` as type == dict, "
                                    "keys need to contain [`i` and `j`] or "

--- a/pyemu/pst/pst_utils.py
+++ b/pyemu/pst/pst_utils.py
@@ -853,49 +853,52 @@ def csv_to_ins_file(csv_filename,ins_filename=None,only_cols=None,only_rows=None
         [f.write("l1\n") for _ in range(head_lines_len)]
         if includes_header:
             f.write("l1\n")  # skip the row (index) label
-        for i,rlabel in enumerate(rlabels):
+        for i,rlabel in enumerate(rlabels):  # loop over rows
             f.write("l1")
             c_count = 0
-            for j,clabel in enumerate(clabels):
-                if c_count < len(only_clabels):
+            for j,clabel in enumerate(clabels):  # loop over columns
+                if c_count < len(only_clabels):  # if we haven't yet set up all obs
                     if rlabel in only_rlabels and clabel in only_clabels:
+                        # define obs names
                         if longnames:
                             nname = "{0}_use_col:{1}".format(prefix, clabel)
                             oname = "{0}_{1}".format(nname, rlabel)
                         else:
                             nname = prefix+clabel
                             oname = prefix+rlabel+"_"+clabel
-                        onames.append(oname)
-                        ovals.append(df.iloc[i,j])
+                        onames.append(oname)  # append list of obs
+                        ovals.append(df.iloc[i, j])  # store current obs val
+                        # defin group name
                         if gpname is False or gpname[c_count] is False:
                             # keeping consistent behaviour
                             ngpname = None  # nname
                         elif gpname is True or gpname[c_count] is True:
-                            ngpname = nname
-                        else:
+                            ngpname = nname  #  set to base of obs name
+                        else:  # a group name has been specified
                             if not isinstance(gpname, str):
                                 ngpname = gpname[c_count]
                             else:
                                 ngpname = gpname
-                        ognames.append(ngpname)
+                        ognames.append(ngpname)  # add to list of group names
+                        # start defining string to write in ins
                         oname = " !{0}!".format(oname)
                         if sep == ',':
-                            oname = "{0} {1},{1}".format(oname, marker)
+                            if j < len(clabels) - 1:
+                                # obs will be follwed by another delim
+                                oname = "{0} {1},{1}".format(oname, marker)
                         c_count += 1
-                    else:
+                    else:  # not a requested observation; add spacer
                         if sep == ',':
                             oname = " {0},{0}".format(marker)
                         else:
                             oname = " w"
                     if j == 0:
+                        # if first col and input file has an index need additional spacer
                         if includes_index:
                             if sep == ',':
                                 f.write(" {0},{0}".format(marker))
                             else:
                                 f.write(" w")
-                    # else:
-                    #     if sep == ',':
-                    #         oname = "{0} {1},{1}".format(oname, marker)
                     f.write(oname)
             f.write('\n')
     odf = pd.DataFrame({"obsnme": onames, "obsval": ovals, 'obgnme': ognames},

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -3329,7 +3329,7 @@ def apply_genericlist_pars(df):
             mlt_cols = [str(col) for col in mlt.use_cols]
             new_df.loc[common_idx, mlt_cols] = (new_df.loc[common_idx, mlt_cols]
                                                 * mlts.loc[common_idx, mlt_cols]
-                                                )
+                                                ).values
             # bring mult index back to columns AND re-order
             new_df = new_df.reset_index().set_index(
                 'oidx')[org_data.columns].sort_index()


### PR DESCRIPTION
Adding some default behaviour for dealing with list pars co-located in 2D but not in 3D.

+ Fixing issue with ins builder failing when obsval was last column.
+ Added test and fix to deal with repeated pars in list files (i.e. non-unique pars by `index_cols`). Now one par is set up and will be applied to all instances in model input file.