### PR TITLE
feat(helpers): added quantile selection for observation ensembles

### DIFF
--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -310,6 +310,86 @@ def geostatistical_prior_builder(pst, struct_dict, sigma_range=4,
                 #     print(full_cov.names[i])
     return full_cov
 
+def calc_observation_ensemble_quantiles(ens, pst, quantiles, subset_obsnames=None, subset_obsgroups=None):
+    """Given an observation ensemble, and requested quantiles, this function calculates the requested
+       quantile point-by-point in the ensemble. This resulting set of values does not, however, correspond
+       to a single realization in the ensemble. So, this function finds the minimum weighted squared 
+       distance to the quantile and labels it in the ensemble. Also indicates which realizations
+       correspond to the selected quantiles.
+
+    Args:
+        ens (pandas DataFrame): DataFrame read from an observation 
+        pst ([type]): pyemy.Pst object - needed to obtain observation weights
+        quantiles ([type]): iterable of quantiles ranging from 0-1.0 for which results requested
+    Returns:
+        ens (pandas DataFrame): same ens object that was input but with quantile realizations
+                            appended as new rows labelled with 'q_#' where '#' is the slected quantile
+        quantile_idx (dictionary): dictionary with keys being quantiles and values being realizations
+                                corresponding to each realization
+    """
+    #TODO: handle zero weights due to PDC
+    
+    quantile_idx = {}
+    # make sure quantiles and subset names and groups are lists
+    if not isinstance(quantiles, list):
+        quantiles = list(quantiles)
+    if not isinstance(subset_obsnames, list) and subset_obsnames is not None:
+        subset_obsnames = list(subset_obsnames)
+    if not isinstance(subset_obsgroups, list) and subset_obsgroups is not None:
+        subset_obsgroups = list(subset_obsgroups)
+    
+        
+    if 'real_name' in ens.columns:
+        ens.set_index('real_name')
+    if not isinstance(pst, pyemu.Pst):
+        raise Exception('pst object must be of type pyemu.Pst')
+ 
+    # get the observation data
+    obs = pst.observation_data.copy()
+    
+    # confirm that the indices and weights line up
+    if  False in np.unique(ens.columns == obs.index):
+        raise Exception('ens and pst observation names do not align')
+    
+    # deal with any subsetting of observations that isn't handled through weights
+    
+    trimnames = obs.index.values
+    if subset_obsgroups is not None and subset_obsnames is not None:
+        raise Exception('can only specify information in one of subset_obsnames of subset_obsgroups. not both')
+    
+    if subset_obsnames is not None:
+        trimnames = subset_obsnames
+        if len(set(trimnames) - set(obs.index.values)) is not 0:
+            raise Exception('the following names in subset_obsnames are not in the ensemble:\n' +
+                            ['{}\n'.format(i) for i in (set(trimnames) - set(obs.index.values))])
+
+    
+    if subset_obsgroups is not None:
+        if len((set(subset_obsgroups) - set(pst.obs_groups))) is not 0:
+            raise Exception('the following groups in subset_obsgroups are not in pst:\n' +
+                ['{}\n'.format(i) for i in (set(subset_obsgroups) - set(pst.obs_groups))])
+
+        trimnames = obs.loc[obs.obgnme.isin(subset_obsgroups)].obsnme.tolist()
+        if len((set(trimnames) - set(obs.index.values)))is not 0:
+            raise Exception('the following names in subset_obsnames are not in the ensemble:\n' +
+                ['{}\n'.format(i) for i in (set(trimnames) - set(obs.index.values))])
+    # trim the data to subsets (or complete )    
+    ens_eval = ens[trimnames].copy()
+    weights = obs.loc[trimnames].weight.values
+    
+    for cq in quantiles:
+        # calculate the point-wise quantile values
+        qfit = np.quantile(ens_eval, cq, axis=0)
+        # calculate the weighted distance between all reals and the desired quantile
+        qreal = np.argmin(np.linalg.norm([(i - qfit)*weights for i in ens_eval.values], axis=1))
+        quantile_idx['q{}'.format(cq)] = qreal
+        ens = ens.append(ens.iloc[qreal])
+        idx = ens.index.values
+        idx[-1] = 'q{}'.format(cq)
+        ens.set_index(idx, inplace=True)
+
+    return ens, quantile_idx
+
 
 def _condition_on_par_knowledge(cov, par_knowledge_dict):
     """  experimental function to include conditional prior information
@@ -615,7 +695,6 @@ def _regweight_from_parbound(pst):
         else:
             print("prior information name does not correspond" + \
                   " to a parameter: " + str(parnme))
-
 
 def first_order_pearson_tikhonov(pst, cov, reset=True, abs_drop_tol=1.0e-3):
     """setup preferred-difference regularization from a covariance matrix.


### PR DESCRIPTION
Added a function in `utils.helpers.py` to return a quantile realization from an ensemble. It's calculated by finding the qth quantile as requested at each point in the ensemble (this is not an actual realization, though - too smooth) and then finding the actual realization with the smallest distance in a weighted sum of squares sense from that vector. 

Returns an augmented ensemble dataframe with the quantile realizations repeated at the end labeled with their quantile value. Also returns a dictionary with `real_name` for each quantile to be used if user wants to access the parameter sets corresponding to those quantiles in the observations.

User can optionally provide either a list of observation names  or groups to be used in the evaluation (note - in any case, the entire ensemble is returned, but quantile calculations are only made using the subset if it is selected). This allows a user to potentially focus in on a quantity of interest, or a subset of interest.