### PR TITLE
Fix for apply_mult broadcasting issues.

### DIFF
--- a/autotest/pst_from_tests.py
+++ b/autotest/pst_from_tests.py
@@ -1301,9 +1301,9 @@ def mf6_freyberg_direct_test():
             raise Exception("recharge too diff")
 
 if __name__ == "__main__":
-    #freyberg_test()
-    #freyberg_prior_build_test()
-    mf6_freyberg_test()
-    #mf6_freyberg_shortnames_test()
-    #mf6_freyberg_da_test()
-    #mf6_freyberg_direct_test()
+    freyberg_test()
+    # freyberg_prior_build_test()
+    # mf6_freyberg_test()
+    # mf6_freyberg_shortnames_test()
+    # mf6_freyberg_da_test()
+    # mf6_freyberg_direct_test()

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -3512,7 +3512,8 @@ def apply_genericlist_pars(df):
                     names=mlt.index_cols)
                 if mlts.index.nlevels < 2:  # just in case only one index col is used
                     mlts.index = mlts.index.get_level_values(0)
-                common_idx = new_df.index.intersection(mlts.index).sort_values()
+                common_idx = new_df.index.intersection(
+                    mlts.index).sort_values().drop_duplicates()
                 mlt_cols = [str(col) for col in mlt.use_cols]
                 new_df.loc[common_idx, mlt_cols] = (new_df.loc[common_idx, mlt_cols]
                                                     * mlts.loc[common_idx, mlt_cols]


### PR DESCRIPTION
Fixing issues with duplicated indicies in pandas.index.intersection() #162 

Pandas 1.1 changed behaviour of index.intersection() to return duplicated indicies in the intersection.
This causes issues in the application of mults as .loc methods propagate this duplication (doubling duplicates).
Adding .drop_duplicates() to the intersection fixes this.