### PR TITLE
supporting specifying times for consistent budget obs setup

### DIFF
--- a/autotest/utils_tests.py
+++ b/autotest/utils_tests.py
@@ -637,6 +637,7 @@ def ppk2fac_verf_test():
 def mflist_budget_test():
     import pyemu
     import os
+    import pandas as pd
     try:
         import flopy
     except:
@@ -648,6 +649,19 @@ def mflist_budget_test():
     assert os.path.exists(list_filename)
     df = pyemu.gw_utils.setup_mflist_budget_obs(list_filename,start_datetime=ml.start_datetime)
     print(df)
+
+    times = df.loc[df.index.str.startswith('vol_wells')].index.str.split(
+        '_', expand=True).get_level_values(2)[::100]
+    times = pd.to_datetime(times, yearfirst=True)
+    df = pyemu.gw_utils.setup_mflist_budget_obs(
+        list_filename, start_datetime=ml.start_datetime, specify_times=times)
+    flx, vol = pyemu.gw_utils.apply_mflist_budget_obs(
+        list_filename, 'flux.dat', 'vol.dat', start_datetime=ml.start_datetime,
+        times='budget_times.config'
+    )
+    assert (flx.index == vol.index).all()
+    assert (flx.index == times).all()
+
 
 def mtlist_budget_test():
     import pyemu
@@ -1845,7 +1859,7 @@ if __name__ == "__main__":
     #geostat_prior_builder_test()
     #geostat_draws_test()
     #jco_from_pestpp_runstorage_test()
-    # mflist_budget_test()
+    mflist_budget_test()
     #mtlist_budget_test()
     # tpl_to_dataframe_test()
     # kl_test()
@@ -1880,4 +1894,4 @@ if __name__ == "__main__":
     # ok_grid_zone_test()
     # ppk2fac_verf_test()
     #ok_grid_invest()
-    maha_pdc_test()
+    # maha_pdc_test()


### PR DESCRIPTION
Recently noticed that if a timestep fails, MODFLOW-NWT writes the budget info for the failed step to mflistfile. Which is then harvested by the `flopy.utils.MfListBudget().get_dataframes()` methods. This could cause misalignment of model output and instruction files if no output was expected for that kstp (which might be the case is only printing budget infor at the end of stress periods).

Have added a quick work-around to the setup and apply methods to allow user to specify the times of interest. Currently not very flexible about the format of the requested `times` array -- onus on the user to make sure that it matches the index of the dataframes that flopy returns when parsing the budget files (array of datetimes should work most of the time I think).

N.B. this does not affect the automatic setup in `PstFromFlopyModel()`. 