### PR TITLE
Feat ipstartworkers

### DIFF
--- a/autotest/pst_tests.py
+++ b/autotest/pst_tests.py
@@ -962,13 +962,13 @@ if __name__ == "__main__":
     # change_limit_test()
     # new_format_test()
     # lt_gt_constraint_names_test()
-    # csv_to_ins_test()
+    csv_to_ins_test()
 
     # try_process_ins_test()
     # write_tables_test()
     # res_stats_test()
     # test_write_input_files()
-    add_obs_test()
+    #add_obs_test()
     #add_pars_test()
     # setattr_test()
 

--- a/pyemu/pst/pst_utils.py
+++ b/pyemu/pst/pst_utils.py
@@ -1155,7 +1155,7 @@ def csv_to_ins_file(
 
 
                 if c_count < only_clabels_len:
-                    if clabel in only_clabels and rlabel in only_rlabels:
+                    if clabel in only_clabels:# and rlabel in only_rlabels:
                         oname = ""
                         # define obs names
                         if not prefix_is_str:

--- a/pyemu/pst/pst_utils.py
+++ b/pyemu/pst/pst_utils.py
@@ -1136,7 +1136,9 @@ def csv_to_ins_file(
             f.write("l1\n")  # skip the row (index) label
         for i, rlabel in enumerate(rlabels):  # loop over rows
             f.write("l1")
-
+            if (rlabel not in only_rlabels):
+                f.write("\n")
+                continue
             c_count = 0
             line = ''
             for j, clabel in enumerate(clabels):  # loop over columns

--- a/pyemu/utils/os_utils.py
+++ b/pyemu/utils/os_utils.py
@@ -165,7 +165,8 @@ def start_workers(
             This option is usually not needed unless you are one of those crazy people who
             spreads files across countless subdirectories.
         local (`bool`, optional): flag for using "localhost" instead of actual hostname/IP address on
-            worker command line. Default is True
+            worker command line. Default is True.  `local` can also be passed as an `str`, in which
+            case `local` is used as the hostname (for example `local="192.168.10.1"`)
         cleanup (`bool`, optional):  flag to remove worker directories once processes exit. Default is
             True.  Set to False for debugging issues
         master_dir (`str`): name of directory for master instance.  If `master_dir`

--- a/pyemu/utils/os_utils.py
+++ b/pyemu/utils/os_utils.py
@@ -218,7 +218,9 @@ def start_workers(
     else:
         if not os.path.exists(os.path.join(worker_dir, pst_rel_path)):
             raise Exception("pst_rel_path not found from worker_dir")
-    if local:
+    if isinstance(local,str):
+        hostname = local
+    elif local:
         hostname = "localhost"
     else:
         hostname = socket.gethostname()


### PR DESCRIPTION
added option to treat `local` arg to `start_workers` as a hostname string.  Also added check to skip unused rows in `csv_to_ins`