### PR TITLE
Feat conditionalcov

### DIFF
--- a/autotest/pst_from_tests.py
+++ b/autotest/pst_from_tests.py
@@ -191,7 +191,7 @@ def freyberg_test():
     pf.add_parameters(filenames="WEL_0000.dat",
                       par_type="grid", index_cols=[0, 1, 2], use_cols=3,
                       par_name_base="welflux_grid_direct",
-                      zone_array=zone_array,par_style="direct")
+                      zone_array=zone_array,par_style="direct",transform="none")
     pf.add_parameters(filenames=["WEL_0000.dat"], par_type="constant",
                       index_cols=[0, 1, 2], use_cols=3,
                       par_name_base=["flux_const"])
@@ -3003,10 +3003,10 @@ def usg_freyberg_test():
 if __name__ == "__main__":
     #mf6_freyberg_pp_locs_test()
     #invest()
-    #freyberg_test()
+    freyberg_test()
     #freyberg_prior_build_test()
     #mf6_freyberg_test()
-    mf6_freyberg_da_test()
+    #mf6_freyberg_da_test()
     #mf6_freyberg_shortnames_test()
     #mf6_freyberg_direct_test()
     #mf6_freyberg_varying_idomain()

--- a/autotest/utils_tests.py
+++ b/autotest/utils_tests.py
@@ -1832,6 +1832,45 @@ def gsf_reader_test():
 
     assert len(gsf.get_node_data()) == nnodes
 
+def conditional_prior_test():
+    import os
+    import numpy as np
+    import pyemu
+
+    prior_var = 1.0
+    cond_var = 0.5
+    v = pyemu.geostats.ExpVario(contribution=prior_var,a=5.0)
+    gs = pyemu.geostats.GeoStruct(variograms=v,transform="none")
+    x = np.arange(100)
+    y = np.zeros_like(x)
+    names = ["n{0}".format(i) for i in range(x.shape[0])]
+    cov = gs.covariance_matrix(x,y,names)
+    know_dict = {n:cond_var for n in [cov.col_names[int(x.shape[0]/2)],cov.col_names[int(3*x.shape[0]/4)]]}
+    #know_dict = {cov.col_names[]:0.0001,cov.col_names[3]:0.0025}
+    cond_cov = pyemu.helpers._condition_on_par_knowledge(cov,know_dict)
+    i = int(x.shape[0] / 2)
+    print(cov.x[i,i],cond_cov.x[i,i])
+    print(np.diag(cov.x).min(), np.diag(cond_cov.x).min())
+    print(prior_var,cond_var)
+
+
+    # import matplotlib.pyplot as plt
+    # fig,axes = plt.subplots(1,3,figsize=(15,5))
+    # thres = 0.001
+    # x1 = cov.to_pearson().x.copy()
+    # x1[np.abs(x1) < thres] = np.nan
+    # x2 = cond_cov.to_pearson().x.copy()
+    # x2[np.abs(x2) < thres] = np.nan
+    #
+    # axes[0].imshow(x1,vmin=0.0,vmax=1.0)
+    # axes[1].imshow(x2,vmin=0.0,vmax=1.0)
+    # axes[2].plot(np.diag(cov.x),"0.5",label="prior diag")
+    # axes[2].plot(np.diag(cond_cov.x), "b",label="post diag")
+    # axes[0].set_title("prior CC matrix, variance {0}".format(prior_var),loc="left")
+    # axes[1].set_title("post CC matrix, conditional variance {0}".format(cond_var), loc="left")
+    # axes[2].set_title("prior vs posterior diagonals", loc="left")
+    #
+    # plt.show()
 
 
 if __name__ == "__main__":
@@ -1866,10 +1905,10 @@ if __name__ == "__main__":
     # gslib_2_dataframe_test()
     # sgems_to_geostruct_test()
     # #linearuniversal_krige_test()
-    #geostat_prior_builder_test()
+    conditional_prior_invest()
     #geostat_draws_test()
     #jco_from_pestpp_runstorage_test()
-    # mflist_budget_test()
+    #mflist_budget_test()
     #mtlist_budget_test()
     # tpl_to_dataframe_test()
     # kl_test()
@@ -1905,4 +1944,4 @@ if __name__ == "__main__":
     # ppk2fac_verf_test()
     #ok_grid_invest()
     # maha_pdc_test()
-    gsf_reader_test()
+    #gsf_reader_test()

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -511,43 +511,49 @@ def calc_rmse_ensemble(ens, pst, bygroups=True, subset_realizations=None):
     return rmse
 
 
-def _condition_on_par_knowledge(cov, par_knowledge_dict):
-    """experimental function to include conditional prior information
-    for one or more parameters in a full covariance matrix
+def _condition_on_par_knowledge(cov, var_knowledge_dict):
+    """experimental function to condition a covariance matrix with the variances of new information.
+
+    Args:
+        cov (`pyemu.Cov`): prior covariance matrix
+        var_knowledge_dict (`dict`): a dictionary of covariance entries and variances
+
+    Returns:
+        cov (`pyemu.Cov`): the conditional covariance matrix
+
     """
 
     missing = []
-    for parnme in par_knowledge_dict.keys():
-        if parnme not in cov.row_names:
-            missing.append(parnme)
+    for name in var_knowledge_dict.keys():
+        if name not in cov.row_names:
+            missing.append(name)
     if len(missing):
         raise Exception(
-            "par knowledge dict parameters not found: {0}".format(",".join(missing))
+            "var knowledge dict entries not found: {0}".format(",".join(missing))
         )
-    # build the selection matrix and sigma epsilon
-    # sel = pyemu.Cov(x=np.identity(cov.shape[0]),names=cov.row_names)
-    sel = cov.zero2d
-    sel = cov.to_pearson()
-    new_cov_diag = pyemu.Cov(x=np.diag(cov.as_2d.diagonal()), names=cov.row_names)
-    # new_cov_diag = cov.zero2d
+    if cov.isdiagonal:
+        raise Exception("_condition_on_par_knowledge(): cov is diagonal, simply update the par variances")
+    know_names = list(var_knowledge_dict.keys())
+    know_names.sort()
+    know_cross_cov = cov.get(cov.row_names,know_names)
 
-    for parnme, var in par_knowledge_dict.items():
-        idx = cov.row_names.index(parnme)
-        # sel.x[idx,:] = 1.0
-        # sel.x[idx,idx] = var
-        new_cov_diag.x[idx, idx] = var  # cov.x[idx,idx]
-    new_cov_diag = sel * new_cov_diag * sel.T
+    know_cov = cov.get(know_names,know_names)
+    # add the par knowledge to the diagonal of know_cov
+    for i,name in enumerate(know_names):
+        know_cov.x[i,i] += var_knowledge_dict[name]
 
-    for _ in range(2):
-        for parnme, var in par_knowledge_dict.items():
-            idx = cov.row_names.index(parnme)
-            # sel.x[idx,:] = 1.0
-            # sel.x[idx,idx] = var
-            new_cov_diag.x[idx, idx] = var  # cov.x[idx,idx]
-        new_cov_diag = sel * new_cov_diag * sel.T
+    # kalman gain
+    k_gain = know_cross_cov * know_cov.inv
+    #selection matrix
+    h = k_gain.zero2d.T
+    know_dict = {n:i for i,n in enumerate(know_names)}
+    for i,name in enumerate(cov.row_names):
+        if name in know_dict:
+            h.x[know_dict[name],i] = 1.0
 
-    print(new_cov_diag)
-    return new_cov_diag
+    prod = k_gain * h
+    conditional_cov = (prod.identity - prod) * cov
+    return conditional_cov
 
 
 def kl_setup(


### PR DESCRIPTION
using formal bayes linear/kalman theory to condition a covariance matrix with new info.  Still needs some thinking about how to use it to build more informed priors (a la #231 ) because as @aymanalz pointed out to me, even specifying an updated variance that is equal to the current variance conceptually provides new information, so that conditional variance will decrease.  So currently, the variance info provided does not end up on the diagonal of the new conditional covariance matrix.  but this is start at least...also fixed a bug in the pst from tests.