### PR TITLE
Feat covscaling

### DIFF
--- a/autotest/utils_tests.py
+++ b/autotest/utils_tests.py
@@ -1937,7 +1937,7 @@ def geostat_prior_builder_test2():
     print(ed.max())
     assert ed.max() < 1.0e-1
 
-    import matplotlib.pyplot as plt
+    #import matplotlib.pyplot as plt
     # fig,ax = plt.subplots(1,1)
     # ax.plot(ed)
     # axt = plt.twinx(ax)
@@ -1948,11 +1948,11 @@ def geostat_prior_builder_test2():
     # ax.set_xticklabels(pst.par_names[10:100],rotation=90)
     # plt.show()
     #
-    fig,axes = plt.subplots(1,3,figsize=(15,5))
-    axes[0].imshow(x1[:200,:200],cmap="jet",vmax=np.nanmax(x2[:200,:200]),vmin=np.nanmin(x2[:200,:200]))
-    axes[1].imshow(x2[:200, :200], cmap="jet",vmax=np.nanmax(x2[:200,:200]),vmin=np.nanmin(x2[:200,:200]))
-    axes[2].imshow(ex2[:200, :200], cmap="jet",vmax=np.nanmax(x2[:200,:200]),vmin=np.nanmin(x2[:200,:200]))
-    plt.show()
+    #fig,axes = plt.subplots(1,3,figsize=(15,5))
+    #axes[0].imshow(x1[:200,:200],cmap="jet",vmax=np.nanmax(x2[:200,:200]),vmin=np.nanmin(x2[:200,:200]))
+    #axes[1].imshow(x2[:200, :200], cmap="jet",vmax=np.nanmax(x2[:200,:200]),vmin=np.nanmin(x2[:200,:200]))
+    #axes[2].imshow(ex2[:200, :200], cmap="jet",vmax=np.nanmax(x2[:200,:200]),vmin=np.nanmin(x2[:200,:200]))
+    #plt.show()
 
 
 if __name__ == "__main__":

--- a/autotest/utils_tests.py
+++ b/autotest/utils_tests.py
@@ -1890,10 +1890,10 @@ def geostat_prior_builder_test2():
     
     par = pst.parameter_data
     #give some pars narrower bounds to induce a lower variance 
-    par.loc[pst.par_names[10:40], "parubnd"] = par.loc[pst.par_names[10:40], "parval1"] * 1.5
-    par.loc[pst.par_names[10:40], "parlbnd"] = par.loc[pst.par_names[10:40], "parval1"] * 0.5
-    par.loc[pst.par_names[40:100], "parubnd"] *= 100
-    par.loc[pst.par_names[40:100], "parlbnd"] *= .01
+    #par.loc[pst.par_names[10:40], "parubnd"] = par.loc[pst.par_names[10:40], "parval1"] * 1.5
+    #par.loc[pst.par_names[10:40], "parlbnd"] = par.loc[pst.par_names[10:40], "parval1"] * 0.5
+    par.loc[pst.par_names[10:100], "parubnd"] *= np.random.random(90) * 5
+    par.loc[pst.par_names[10:100], "parlbnd"] *= np.random.random(90) * 0.5
     
     
     # get a diagonal bounds-based cov
@@ -1937,7 +1937,7 @@ def geostat_prior_builder_test2():
     print(ed.max())
     assert ed.max() < 1.0e-1
 
-    # import matplotlib.pyplot as plt
+    import matplotlib.pyplot as plt
     # fig,ax = plt.subplots(1,1)
     # ax.plot(ed)
     # axt = plt.twinx(ax)
@@ -1948,11 +1948,11 @@ def geostat_prior_builder_test2():
     # ax.set_xticklabels(pst.par_names[10:100],rotation=90)
     # plt.show()
     #
-    # fig,axes = plt.subplots(1,3,figsize=(15,5))
-    # axes[0].imshow(x1[:200,:200],cmap="jet")
-    # axes[1].imshow(x2[:200, :200], cmap="jet")
-    # axes[2].imshow(ex2[:200, :200], cmap="jet")
-    # plt.show()
+    fig,axes = plt.subplots(1,3,figsize=(15,5))
+    axes[0].imshow(x1[:200,:200],cmap="jet",vmax=np.nanmax(x2[:200,:200]),vmin=np.nanmin(x2[:200,:200]))
+    axes[1].imshow(x2[:200, :200], cmap="jet",vmax=np.nanmax(x2[:200,:200]),vmin=np.nanmin(x2[:200,:200]))
+    axes[2].imshow(ex2[:200, :200], cmap="jet",vmax=np.nanmax(x2[:200,:200]),vmin=np.nanmin(x2[:200,:200]))
+    plt.show()
 
 
 if __name__ == "__main__":

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -169,14 +169,17 @@ def geostatistical_draws(
 
                 if verbose:
                     print("getting diag var cov", df_zone.shape[0])
-                # tpl_var = np.diag(full_cov.get(list(df_zone.parnme)).x).max()
-                tpl_var = max([full_cov_dict[pn] for pn in df_zone.parnme])
-
+                
+                #tpl_var = max([full_cov_dict[pn] for pn in df_zone.parnme])
                 if verbose:
                     print("scaling full cov by diag var cov")
-                # cov.x *= tpl_var
-                for i in range(cov.shape[0]):
-                    cov.x[i, :] *= tpl_var
+                
+                # for i in range(cov.shape[0]):
+                #     cov.x[i, :] *= tpl_var
+                for i,name in enumerate(cov.row_names):
+                    cov.x[:,i] *= np.sqrt(full_cov_dict[name])
+                    cov.x[i, :] *= np.sqrt(full_cov_dict[name])
+                    cov.x[i, i] = full_cov_dict[name]
                 # no fixed values here
                 pe = pyemu.ParameterEnsemble.from_gaussian_draw(
                     pst=pst, cov=cov, num_reals=num_reals, by_groups=False, fill=False
@@ -322,15 +325,17 @@ def geostatistical_prior_builder(
                 # find the variance in the diagonal cov
                 if verbose:
                     print("getting diag var cov", df_zone.shape[0])
-                # tpl_var = np.diag(full_cov.get(list(df_zone.parnme)).x).max()
-                tpl_var = max([full_cov_dict[pn] for pn in df_zone.parnme])
-                # if np.std(tpl_var) > 1.0e-6:
-                #    warnings.warn("pars have different ranges" +\
-                #                  " , using max range as variance for all pars")
-                # tpl_var = tpl_var.max()
+
+                #tpl_var = max([full_cov_dict[pn] for pn in df_zone.parnme])
+
                 if verbose:
                     print("scaling full cov by diag var cov")
-                cov *= tpl_var
+
+                #cov *= tpl_var
+                for i,name in enumerate(cov.row_names):
+                    cov.x[:,i] *= np.sqrt(full_cov_dict[name])
+                    cov.x[i, :] *= np.sqrt(full_cov_dict[name])
+                    cov.x[i, i] = full_cov_dict[name]
                 if verbose:
                     print("test for inversion")
                 try:

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -177,6 +177,7 @@ def geostatistical_draws(
                 # for i in range(cov.shape[0]):
                 #     cov.x[i, :] *= tpl_var
                 for i,name in enumerate(cov.row_names):
+                    #print(name,full_cov_dict[name])
                     cov.x[:,i] *= np.sqrt(full_cov_dict[name])
                     cov.x[i, :] *= np.sqrt(full_cov_dict[name])
                     cov.x[i, i] = full_cov_dict[name]
@@ -184,7 +185,6 @@ def geostatistical_draws(
                 pe = pyemu.ParameterEnsemble.from_gaussian_draw(
                     pst=pst, cov=cov, num_reals=num_reals, by_groups=False, fill=False
                 )
-                # df = pe.iloc[:,:]
                 par_ens.append(pe._df)
                 pars_in_cov.update(set(pe.columns))
 


### PR DESCRIPTION
added some new hackery to support intra-group variance variability between parameters for #231 .  This is done by scaling the row and column of the correlation coef matrix by the parameter's standard deviation, which transforms the correlation coef matrix into a covariance matrix.  Currently, not enforcing the geostruct to have a sill of 1.0.  Maybe this is something to consider.  If we like this approach, then I think this will open up the ability to pass arrays or lookup functions to `PstFrom.add_parameteres()` upper and lower bound arguments.