### PR TITLE
Supporting setup of all cols as observation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ platform: x64
 environment:
   
   matrix:
-    - PYTHON_VERSION: "3.6"
+    - PYTHON_VERSION: "3.7"
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
 
 build: false

--- a/autotest/pst_from_tests.py
+++ b/autotest/pst_from_tests.py
@@ -12,7 +12,7 @@ from pyemu.utils import PstFrom, pp_file_to_dataframe, write_pp_file
 import shutil
 
 ext = ''
-local_bins = False  # change if wanting to test with local binary exes
+local_bins = True  # change if wanting to test with local binary exes
 if local_bins:
     bin_path = os.path.join("..", "..", "bin")
     if "linux" in platform.platform().lower():
@@ -2680,10 +2680,9 @@ def mf6_freyberg_arr_obs_and_headerless_test():
     obs = pst.observation_data
     for fname,arr in arr_dict.items():
 
-        fobs = obs.loc[obs.obsnme.str.contains(fname),:]
+        fobs = obs.loc[obs.obsnme.str.contains(Path(fname).stem), :]
         #print(fobs)
-        fobs.loc[:,"i"] = fobs.i.apply(np.int)
-        fobs.loc[:, "j"] = fobs.j.apply(np.int)
+        fobs = fobs.astype({c: int for c in ['i', 'j']})
 
         pval = fobs.loc[fobs.apply(lambda x: x.i==3 and x.j==1,axis=1),"obsval"]
         assert len(pval) == 1
@@ -3052,6 +3051,8 @@ def mf6_add_various_obs_test():
     pf.add_observations("freyberg6.npf_k_layer2.txt",
                         zone_array=m.dis.idomain.array[0],
                         prefix='lay2k')
+    pf.add_observations("freyberg6.npf_k_layer3.txt",
+                        zone_array=m.dis.idomain.array[0])
     # TODO more variations on the theme
     pst = pf.build_pst('freyberg.pst')
 
@@ -3073,7 +3074,7 @@ if __name__ == "__main__":
     #tpf.test_add_direct_array_parameters()
     #tpf.add
     #pstfrom_profile()
-    #mf6_freyberg_arr_obs_and_headerless_test()\
+    mf6_freyberg_arr_obs_and_headerless_test()
     # usg_freyberg_test()
 
 

--- a/autotest/pst_from_tests.py
+++ b/autotest/pst_from_tests.py
@@ -1695,7 +1695,6 @@ def mf6_freyberg_varying_idomain():
         print(model_file,sim_val,arr.mean())
 
 
-
 def xsec_test():
     import numpy as np
     import pandas as pd
@@ -1745,6 +1744,7 @@ def xsec_test():
     pst = pyemu.Pst(os.path.join(t_d,"pest.pst"))
     print(pst.phi)
     assert pst.phi < 1.0e-7
+
 
 def mf6_freyberg_short_direct_test():
 
@@ -3017,6 +3017,38 @@ def usg_freyberg_test():
         assert d.sum() > 1.0e-3, arr_file
 
 
+def mf6_add_various_obs_test():
+    import flopy
+    org_model_ws = os.path.join('..', 'examples', 'freyberg_mf6')
+    tmp_model_ws = "temp_pst_from"
+    if os.path.exists(tmp_model_ws):
+        shutil.rmtree(tmp_model_ws)
+    os.mkdir(tmp_model_ws)
+    sim = flopy.mf6.MFSimulation.load(sim_ws=org_model_ws)
+    # sim.set_all_data_external()
+    sim.simulation_data.mfpath.set_sim_path(tmp_model_ws)
+    # sim.set_all_data_external()
+    m = sim.get_model("freyberg6")
+    # sim.set_all_data_external(check_data=False)
+    sim.write_simulation()
+
+    # SETUP pest stuff...
+    os_utils.run("{0} ".format(mf6_exe_path), cwd=tmp_model_ws)
+
+    template_ws = "new_temp"
+    sr = m.modelgrid
+    # set up PstFrom object
+    pf = PstFrom(original_d=tmp_model_ws, new_d=template_ws,
+                 remove_existing=True,
+                 longnames=True, spatial_reference=sr,
+                 zero_based=False, start_datetime="1-1-2018",
+                 chunk_len=1)
+
+    # blind obs add
+    pf.add_observations("sfr.csv", insfile="sfr.csv.ins", index_cols=0)
+    # TODO more variations on the theme
+    pst = pf.build_pst('freyberg.pst')
+
 if __name__ == "__main__":
     #mf6_freyberg_pp_locs_test()
     #invest()
@@ -3024,18 +3056,19 @@ if __name__ == "__main__":
     #freyberg_prior_build_test()
     #mf6_freyberg_test()
     #mf6_freyberg_da_test()
-    #mf6_freyberg_shortnames_test()
+    # mf6_freyberg_shortnames_test()
     #mf6_freyberg_direct_test()
     #mf6_freyberg_varying_idomain()
     #xsec_test()
     #mf6_freyberg_short_direct_test()
+    mf6_add_various_obs_test()
     #tpf = TestPstFrom()
     #tpf.setup()
     #tpf.test_add_direct_array_parameters()
     #tpf.add
     #pstfrom_profile()
     #mf6_freyberg_arr_obs_and_headerless_test()\
-    usg_freyberg_test()
+    # usg_freyberg_test()
 
 
 

--- a/autotest/pst_from_tests.py
+++ b/autotest/pst_from_tests.py
@@ -3046,6 +3046,12 @@ def mf6_add_various_obs_test():
 
     # blind obs add
     pf.add_observations("sfr.csv", insfile="sfr.csv.ins", index_cols=0)
+    pf.add_observations("heads.csv", index_cols=0, obsgp='hds')
+    pf.add_observations("freyberg6.npf_k_layer1.txt",
+                        obsgp='hk1', zone_array=m.dis.idomain.array[0])
+    pf.add_observations("freyberg6.npf_k_layer2.txt",
+                        zone_array=m.dis.idomain.array[0],
+                        prefix='lay2k')
     # TODO more variations on the theme
     pst = pf.build_pst('freyberg.pst')
 

--- a/autotest/pst_from_tests.py
+++ b/autotest/pst_from_tests.py
@@ -12,7 +12,7 @@ from pyemu.utils import PstFrom, pp_file_to_dataframe, write_pp_file
 import shutil
 
 ext = ''
-local_bins = True  # change if wanting to test with local binary exes
+local_bins = False  # change if wanting to test with local binary exes
 if local_bins:
     bin_path = os.path.join("..", "..", "bin")
     if "linux" in platform.platform().lower():

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -1,5 +1,6 @@
 name: pyemu
 channels:
+  - conda-forge
   - defaults
 dependencies:  
   - numpy 

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -8,7 +8,6 @@ dependencies:
   - nose-timer
   - nbsphinx
   - matplotlib
-  - pillow
   - coverage
   - coveralls
   - nose

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - nose-timer
   - nbsphinx
   - matplotlib
+  - pillow
   - coverage
   - coveralls
   - nose

--- a/pyemu/utils/pst_from.py
+++ b/pyemu/utils/pst_from.py
@@ -1178,7 +1178,16 @@ class PstFrom(object):
             ofile_sep (`str`): delimiter in output file
             rebuild_pst (`bool`): (Re)Construct PstFrom.pst object after adding
                 new obs
-            obsgp ():
+            obsgp (`str` of `list`-like): observation group name(s). If type
+                `str` (or list of len == 1) and `use_cols` is None (i.e. all
+                non-index cols are to  be set up as obs), the same group name
+                will be mapped to all obs in call. If None the obs group name
+                will be derived from the base of the constructed observation
+                name. If passed as `list` (and len(`list`) = `n` > 1), the
+                entries in obsgp will be interpreted to explicitly define the
+                grouped for the first `n` cols in `use_cols`, any remaining
+                columns will default to None and the base of the observation
+                name will be used. Default is None.
             zone_array (`np.ndarray`): array defining spatial limits or zones
                 for array-style observations. Default is None
             includes_header (`bool`): flag indicating that the list file includes a

--- a/pyemu/utils/pst_from.py
+++ b/pyemu/utils/pst_from.py
@@ -1168,7 +1168,10 @@ class PstFrom(object):
                 as observations
             insfile (`str`): desired instructions file filename
             index_cols (`list`-like or `int`): columns to denote are indices for obs
-            use_cols (`list`-like or `int`): columns to set up as obs
+            use_cols (`list`-like or `int`): columns to set up as obs. If None,
+                and `index_cols` is not None (i.e list-syle obs assumed),
+                observations will be set up for all columns in `filename` that
+                are not in `index_cols`.
             use_rows (`list`-like or `int`): select only specific row of file for obs
             prefix (`str`): prefix for obsnmes
             ofile_skip (`int`): number of lines to skip in model output file

--- a/pyemu/utils/pst_from.py
+++ b/pyemu/utils/pst_from.py
@@ -1156,7 +1156,7 @@ class PstFrom(object):
         ofile_skip=None,
         ofile_sep=None,
         rebuild_pst=False,
-        obsgp=True,
+        obsgp=None,
         zone_array=None,
         includes_header=True,
     ):
@@ -1178,6 +1178,7 @@ class PstFrom(object):
             ofile_sep (`str`): delimiter in output file
             rebuild_pst (`bool`): (Re)Construct PstFrom.pst object after adding
                 new obs
+            obsgp ():
             zone_array (`np.ndarray`): array defining spatial limits or zones
                 for array-style observations. Default is None
             includes_header (`bool`): flag indicating that the list file includes a
@@ -1210,8 +1211,8 @@ class PstFrom(object):
 
 
         """
-        # TODO - array style outputs? or expecting post processing to tabular
-        if insfile is None:
+        use_cols_psd = copy.copy(use_cols)  # store passed use_cols argument
+        if insfile is None: # setup instruction file name
             insfile = "{0}.ins".format(filename)
         self.logger.log("adding observations from tabular output file")
         # precondition arguments
@@ -1241,7 +1242,8 @@ class PstFrom(object):
             self.logger.log(
                 "adding observations from array output file '{0}'".format(filenames)
             )
-            df_obs = self._process_array_obs(
+            # Setup obs for array style output, build and write instruction file
+            self._process_array_obs(
                 filenames,
                 insfile,
                 prefix,
@@ -1250,6 +1252,7 @@ class PstFrom(object):
                 self.longnames,
                 zone_array,
             )
+            # Add obs from inss file written by _process_array_obs()
             new_obs = self.add_observations_from_ins(
                 ins_file=insfile, out_file=self.new_d / filename
             )
@@ -1285,7 +1288,7 @@ class PstFrom(object):
             if use_cols is not None:
                 use_cols = df.iloc[0][use_cols].to_list()  # redefine use_cols
             df = df.rename(columns=df.iloc[0]).drop(0).reset_index(drop=True).apply(pd.to_numeric)
-        # select all non index cols if use_cols is None
+        # Select all non index cols if use_cols is None
         if use_cols is None:
             use_cols = df.columns.drop(index_cols).tolist()
         # Currently just passing through comments in header (i.e. before the table data)
@@ -1300,8 +1303,8 @@ class PstFrom(object):
             self.logger.log(
                 "building insfile for tabular output file {0}" "".format(filename)
             )
+            # Build dataframe from output file df for use in insfile
             df_temp = _get_tpl_or_ins_df(
-                filename,
                 df,
                 prefix,
                 typ="obs",
@@ -1310,6 +1313,7 @@ class PstFrom(object):
                 longnames=self.longnames,
             )
             df.loc[:, "idx_str"] = df_temp.idx_strs
+            # Select only certain rows if requested
             if use_rows is not None:
                 if isinstance(use_rows, str):
                     if use_rows not in df.idx_str:
@@ -1324,10 +1328,26 @@ class PstFrom(object):
                 use_rows = [r for r in use_rows if r <= len(df)]
                 use_rows = df.iloc[use_rows].idx_str.unique()
 
-            # construct ins_file from df
+            # Construct ins_file from df
+            # first rectify group name with number of columns
             ncol = len(use_cols)
-
-            obsgp = _check_var_len(obsgp, ncol, fill=True)
+            fill = True  # default fill=True means that the groupname will be
+                         # derived from the base of the observation name
+            # if passed group name is a string or list with len < ncol
+            # and passed use_cols was None or of len > len(obsgp)
+            if obsgp is not None:
+                if use_cols_psd is None:  # no use_cols defined (all are setup)
+                    if len([obsgp] if isinstance(obsgp, str) else obsgp) == 1:
+                        # only 1 group provided, assume passed obsgp applys
+                        # to all use_cols
+                        fill = 'first'
+                    else:
+                        # many obs groups passed, assume last will fill if < ncol
+                        fill = 'last'
+                # else fill will be set to True (base of obs name will be used)
+            else:
+                obsgp = True  # will use base of col
+            obsgp = _check_var_len(obsgp, ncol, fill=fill)
             df_ins = pyemu.pst_utils.csv_to_ins_file(
                 df.set_index("idx_str"),
                 ins_filename=self.new_d / insfile,
@@ -2676,7 +2696,6 @@ def write_list_tpl(
         )
     else:
         df_tpl = _get_tpl_or_ins_df(
-            filenames,
             dfs,
             name,
             index_cols,
@@ -3006,7 +3025,6 @@ def _write_direct_df_tpl(
 
 
 def _get_tpl_or_ins_df(
-    filenames,
     dfs,
     name,
     index_cols,
@@ -3111,8 +3129,8 @@ def _get_tpl_or_ins_df(
     df_ti.loc[:, "idx_strs"] = df_ti.sidx.apply(lambda x: fmt.format(*x)).str.replace(
         " ", ""
     )
-    df_ti.loc[:, "idx_strs"] = df_ti.idx_strs.str.replace(":", "")
-    df_ti.loc[:, "idx_strs"] = df_ti.idx_strs.str.replace("|", ":")
+    df_ti.loc[:, "idx_strs"] = df_ti.idx_strs.str.replace(":", "", regex=False)
+    df_ti.loc[:, "idx_strs"] = df_ti.idx_strs.str.replace("|", ":", regex=False)
 
     if get_xy is not None:
         if xy_in_idx is not None:

--- a/pyemu/utils/pst_from.py
+++ b/pyemu/utils/pst_from.py
@@ -1269,6 +1269,8 @@ class PstFrom(object):
                 new_obs.loc[:, "obgnme"] = obsgp
             elif prefix is not None:
                 new_obs.loc[:, "obgnme"] = prefix
+            else:
+                new_obs.loc[:, "obgnme"] = "obgnme"
             self.logger.log(
                 "adding observations from array output file '{0}'".format(filenames)
             )


### PR DESCRIPTION
Changed the function of `use_cols=None` (default) int `PstFrom()` when `index_cols!=None` (i.e. when setting up list-style obs). Now obs will be set up for every column that does not appear in `index_cols`.

Also added few lines to rectify loaded df if `index_cols` passed as ints but the first row of df are strings (implying file had column headers). May not be perfect but may catch some "lazy" definitions of `index_cols` and `use_cols`.