### PR TITLE
Speed up processing of output files with lots of columns

### DIFF
--- a/autotest/pst_from_tests.py
+++ b/autotest/pst_from_tests.py
@@ -3018,7 +3018,6 @@ def usg_freyberg_test():
 
 def mf6_add_various_obs_test():
     import flopy
-    # import cProfile
     org_model_ws = os.path.join('..', 'examples', 'freyberg_mf6')
     tmp_model_ws = "temp_pst_from"
     if os.path.exists(tmp_model_ws):
@@ -3056,17 +3055,27 @@ def mf6_add_various_obs_test():
     pf.add_observations("freyberg6.npf_k_layer3.txt",
                         zone_array=m.dis.idomain.array[0])
 
-    df = pd.DataFrame(np.random.random([10, 20000]),
-                      columns=[hex(c) for c in range(20000)])
-    df.index.name = 'time'
-    df.to_csv(os.path.join(template_ws, 'bigobseg.csv'))
-    # pr = cProfile.Profile()
-    # pr.enable()
-    pf.add_observations('bigobseg.csv', index_cols=0)
-    # pr.disable()
+    _add_big_obsffile(pf, profile=True, nchar=50000)
+
     # TODO more variations on the theme
     pst = pf.build_pst('freyberg.pst')
-    # pr.print_stats(sort="cumtime")
+
+
+def _add_big_obsffile(pf, profile=False, nchar=50000):
+    df = pd.DataFrame(np.random.random([10, nchar]),
+                      columns=[hex(c) for c in range(nchar)])
+    df.index.name = 'time'
+    df.to_csv(os.path.join(pf.new_d, 'bigobseg.csv'))
+
+    if profile:
+        import cProfile
+        pr = cProfile.Profile()
+        pr.enable()
+        pf.add_observations('bigobseg.csv', index_cols='time')
+        pr.disable()
+        pr.print_stats(sort="cumtime")
+    else:
+        pf.add_observations('bigobseg.csv', index_cols='time')
 
 
 def mf6_subdir_test():

--- a/autotest/pst_from_tests.py
+++ b/autotest/pst_from_tests.py
@@ -3018,6 +3018,7 @@ def usg_freyberg_test():
 
 def mf6_add_various_obs_test():
     import flopy
+    # import cProfile
     org_model_ws = os.path.join('..', 'examples', 'freyberg_mf6')
     tmp_model_ws = "temp_pst_from"
     if os.path.exists(tmp_model_ws):
@@ -3053,8 +3054,18 @@ def mf6_add_various_obs_test():
                         prefix='lay2k')
     pf.add_observations("freyberg6.npf_k_layer3.txt",
                         zone_array=m.dis.idomain.array[0])
+
+    df = pd.DataFrame(np.random.random([10, 20000]),
+                      columns=[hex(c) for c in range(20000)])
+    df.index.name = 'time'
+    df.to_csv(os.path.join(template_ws, 'bigobseg.csv'))
+    # pr = cProfile.Profile()
+    # pr.enable()
+    pf.add_observations('bigobseg.csv', index_cols=0)
+    # pr.disable()
     # TODO more variations on the theme
     pst = pf.build_pst('freyberg.pst')
+    # pr.print_stats(sort="cumtime")
 
 
 def mf6_subdir_test():
@@ -3380,14 +3391,14 @@ if __name__ == "__main__":
     #mf6_freyberg_varying_idomain()
     #xsec_test()
     #mf6_freyberg_short_direct_test()
-    # mf6_add_various_obs_test()
-    mf6_subdir_test()
+    mf6_add_various_obs_test()
+    # mf6_subdir_test()
     #tpf = TestPstFrom()
     #tpf.setup()
     #tpf.test_add_direct_array_parameters()
     #tpf.add
     #pstfrom_profile()
-    mf6_freyberg_arr_obs_and_headerless_test()
+    # mf6_freyberg_arr_obs_and_headerless_test()
     # usg_freyberg_test()
 
 

--- a/autotest/pst_from_tests.py
+++ b/autotest/pst_from_tests.py
@@ -3045,7 +3045,8 @@ def mf6_add_various_obs_test():
                  chunk_len=1)
 
     # blind obs add
-    pf.add_observations("sfr.csv", insfile="sfr.csv.ins", index_cols=0)
+    pf.add_observations("sfr.csv", insfile="sfr.csv.ins", index_cols='time',
+                        ofile_sep=',')
     pf.add_observations("heads.csv", index_cols=0, obsgp='hds')
     pf.add_observations("freyberg6.npf_k_layer1.txt",
                         obsgp='hk1', zone_array=m.dis.idomain.array[0])

--- a/autotest/pst_from_tests.py
+++ b/autotest/pst_from_tests.py
@@ -3055,27 +3055,48 @@ def mf6_add_various_obs_test():
     pf.add_observations("freyberg6.npf_k_layer3.txt",
                         zone_array=m.dis.idomain.array[0])
 
-    _add_big_obsffile(pf, profile=True, nchar=50000)
+    linelen = 10000
+    _add_big_obsffile(pf, profile=True, nchar=linelen)
 
     # TODO more variations on the theme
-    pst = pf.build_pst('freyberg.pst')
+    # add single par so we can run
+    pf.add_parameters(["freyberg6.npf_k_layer1.txt",
+                       "freyberg6.npf_k_layer2.txt",
+                       "freyberg6.npf_k_layer3.txt"],
+                      index_cols=[0, 1, 2], use_cols=[3], par_type='constant')
+    pf.mod_sys_cmds.append("mf6")
+    pf.add_py_function(
+        'pst_from_tests.py',
+        f"_add_big_obsffile('.', profile=False, nchar={linelen})",
+        is_pre_cmd=False)
+    pst = pf.build_pst('freyberg.pst', version=2)
+    # pst.write(os.path.join(pf.new_d, "freyberg.usg.pst"), version=2)
+    pyemu.os_utils.run("{0} {1}".format(ies_exe_path, pst.filename.name),
+                       cwd=pf.new_d)
 
 
 def _add_big_obsffile(pf, profile=False, nchar=50000):
+    if isinstance(pf, str):
+        pstfrom_add = False
+        wd = pf
+    else:
+        pstfrom_add = True
+        wd = pf.new_d
     df = pd.DataFrame(np.random.random([10, nchar]),
                       columns=[hex(c) for c in range(nchar)])
     df.index.name = 'time'
-    df.to_csv(os.path.join(pf.new_d, 'bigobseg.csv'))
+    df.to_csv(os.path.join(wd, 'bigobseg.csv'))
 
-    if profile:
-        import cProfile
-        pr = cProfile.Profile()
-        pr.enable()
-        pf.add_observations('bigobseg.csv', index_cols='time')
-        pr.disable()
-        pr.print_stats(sort="cumtime")
-    else:
-        pf.add_observations('bigobseg.csv', index_cols='time')
+    if pstfrom_add:
+        if profile:
+            import cProfile
+            pr = cProfile.Profile()
+            pr.enable()
+            pf.add_observations('bigobseg.csv', index_cols='time')
+            pr.disable()
+            pr.print_stats(sort="cumtime")
+        else:
+            pf.add_observations('bigobseg.csv', index_cols='time')
 
 
 def mf6_subdir_test():

--- a/pyemu/pst/pst_utils.py
+++ b/pyemu/pst/pst_utils.py
@@ -1448,55 +1448,67 @@ class InstructionFile(object):
 
     def _execute_ins_line(self, ins_line, ins_lcount):
         """private method to process output file lines with an instruction line"""
-        cursor_pos = 0
-        val_dict = {}
+        cursor_pos = 0  # starting cursor position
+        val_dict = {}  # storage dict for obsname: obsval pairs in line
         # for ii,ins in enumerate(ins_line):
-        ii = 0
+        ii = 0  # counter over instruction entries
         all_markers = True
         line_seps = set([",", " ", "\t"])
-        linelen = len(ins_line)
+        n_ins = len(ins_line)  # number of instructions on line
         while True:
-            if ii >= linelen:
+            if ii >= n_ins:
                 break
-            ins = ins_line[ii]
-            i1 = ins[:1]
+            ins = ins_line[ii]  # extract instruction
+            i1 = ins[:1]  # first char in instruction
             # primary marker
             if ii == 0 and i1 == self._marker:
+                # if first and instruction starts with primary marker
+                # search for presence of primary marker e.g. ~start~
                 mstr = ins.replace(self._marker, "")
                 while True:
-                    line = self._readline_output()
-                    rline = line.replace(',', ' ')
+                    # loop over lines until primary marker is found
+                    line = self._readline_output()  # read line from output
                     if line is None:
                         self.throw_out_error(
-                            "EOF when trying to find primary marker '{0}' from instruction file line {1}".format(
+                            "EOF when trying to find primary marker '{0}' from "
+                            "instruction file line {1}".format(
                                 mstr, ins_lcount
                             )
                         )
-                    if mstr in line:
+                    if mstr in line:  # when marker is found break and update
+                        # cursor position in current line
                         break
+                # copy a version of line commas replaced
+                # (to support comma sep strings)
+                rline = line.replace(',', ' ')
                 cursor_pos = line.index(mstr) + len(mstr)
 
             # line advance
-            elif i1 == "l":
+            elif i1 == "l":  # if start of instruction is line advance
                 try:
-                    nlines = int(ins[1:])
+                    nlines = int(ins[1:])  # try and get advance number
                 except Exception as e:
                     self.throw_ins_error(
-                        "casting line advance to int for instruction '{0}'".format(ins),
+                        "casting line advance to int for "
+                        "instruction '{0}'".format(ins),
                         ins_lcount,
                     )
                 for i in range(nlines):
                     line = self._readline_output()
-                    rline = line.replace(',', ' ')
                     if line is None:
                         self.throw_out_error(
-                            "EOF when trying to read {0} lines for line advance instruction '{1}', from instruction file line number {2}".format(
+                            "EOF when trying to read {0} lines for line "
+                            "advance instruction '{1}', from instruction "
+                            "file line number {2}".format(
                                 nlines, ins, ins_lcount
                             )
                         )
+                # copy a version of line commas replaced
+                # (to support comma sep strings)
+                rline = line.replace(',', ' ')
             elif ins == "w":  # whole string comparison
-                raw = rline[cursor_pos:].split(None, 2)
-                # raw = line[cursor_pos:].replace(",", " ").split()  # TODO: SLOW FOR LONG STRINGS!
+                raw = rline[cursor_pos:].split(None, 2)  # TODO: maybe sslow for long strings
+                # raw = line[cursor_pos:].replace(",", " ").split()  # TO#DO: SLOW FOR LONG STRINGS!
                 if line[cursor_pos] in line_seps:
                     raw.insert(0, "")
                 if len(raw) == 1:
@@ -1506,16 +1518,18 @@ class InstructionFile(object):
                         )
                     )
                 # step over current value
-                cursor_pos = rline.find(' ', cursor_pos) # cursor_pos + line[cursor_pos:].replace(",", " ").index(" ")  # TODO: SLOW FOR LONG STRINGS!
+                cursor_pos = rline.find(' ', cursor_pos) # cursor_pos + line[cursor_pos:].replace(",", " ").index(" ")  # TO#DO: SLOW FOR LONG STRINGS!
                 # now find position of next entry
-                cursor_pos = rline.find(raw[1], cursor_pos)  # cursor_pos + line[cursor_pos:].replace(",", " ").index(  # TODO: SLOW FOR LONG STRINGS!
+                cursor_pos = rline.find(raw[1], cursor_pos)  # cursor_pos + line[cursor_pos:].replace(",", " ").index(  # TO#DO: SLOW FOR LONG STRINGS!
                    # raw[1]
                # )
 
-            elif i1 == "!":
+            elif i1 == "!":  # indicates obs instruction folows
                 oname = ins.replace("!", "")
                 # look a head for a second/closing marker
-                if ii < linelen - 1 and ins_line[ii + 1] == self._marker:
+                if ii < n_ins - 1 and ins_line[ii + 1] == self._marker:
+                    # if penultimate instruction and last instruction is
+                    # primary marker, look for that marker in line
                     m = ins_line[ii + 1].replace(self._marker, "")
                     es = line.find(m, cursor_pos)
                     if es == -1:  # m not in rest of line
@@ -1524,13 +1538,20 @@ class InstructionFile(object):
                                 m, cursor_pos
                             )
                         )
-                    val_str = line[cursor_pos:es+1]  # .split(m, 1)[0]  # TODO SLOW
+                    # read to closing marker
+                    val_str = line[cursor_pos:es]  # .split(m, 1)[0]  # TO#DO SLOW
                 else:
+                    # find next space in (r)line -- signifies end of entry
                     es = rline.find(' ', cursor_pos)
                     if es == -1 or es == cursor_pos:
+                        # if no space or current position is space
+                        # use old fashioned split to get value
+                        # -- this will happen if there are leading blanks before
+                        # vals in output file (e.g. formatted)
                         val_str = rline[cursor_pos:].split(None, 1)[0]
                     else:
-                        val_str = rline[cursor_pos: es+1]  # .replace(",", " ").split(None, 1)[0]  # TODO SLOW
+                        # read val (constrained slice is faster for big strings)
+                        val_str = rline[cursor_pos: es]  # .replace(",", " ").split(None, 1)[0]  # TO#DO SLOW
                 try:
                     val = float(val_str)
                 except Exception as e:
@@ -1545,11 +1566,12 @@ class InstructionFile(object):
                     val_dict[oname] = val
                 ipos = line.find(val_str.strip(), cursor_pos) # ].index(val_str.strip())  # TODO SLOW
                 # val_len = len(val_str)
-                cursor_pos = ipos + len(val_str)
+                cursor_pos = ipos + len(val_str)  # update cursor
                 all_markers = False
 
             elif i1 == self._marker:
-                m = ins.replace(self._marker, "")
+                m = ins.replace(self._marker, "")  # extract just primary marker
+                # find position of primary marker in line
                 es = line.find(m, cursor_pos)
                 if es == -1:  # m not in rest of line
                     if all_markers:
@@ -1562,7 +1584,7 @@ class InstructionFile(object):
                                 m, cursor_pos
                             )
                         )
-                cursor_pos = line.find(m, cursor_pos) + len(m)
+                cursor_pos = es + len(m)
 
             elif i1 == "(":
                 if ")" not in ins:
@@ -1609,7 +1631,7 @@ class InstructionFile(object):
                     )
 
                 ss_idx = max(cursor_pos, s_idx)
-                raw = line[ss_idx:].split()
+                raw = line[ss_idx:].split(None, 1)  # slpitting only 1 might be margin faster
                 rs_idx = line.index(raw[0])
                 if rs_idx > e_idx:
                     self.throw_out_error(

--- a/pyemu/pst/pst_utils.py
+++ b/pyemu/pst/pst_utils.py
@@ -1455,6 +1455,7 @@ class InstructionFile(object):
         all_markers = True
         line_seps = set([",", " ", "\t"])
         n_ins = len(ins_line)  # number of instructions on line
+        maxsearch = 500  # maximum number of characters to search when slicing line
         while True:
             if ii >= n_ins:
                 break
@@ -1507,8 +1508,7 @@ class InstructionFile(object):
                 # (to support comma sep strings)
                 rline = line.replace(',', ' ')
             elif ins == "w":  # whole string comparison
-                raw = rline[cursor_pos:].split(None, 2)  # TODO: maybe sslow for long strings
-                # raw = line[cursor_pos:].replace(",", " ").split()  # TO#DO: SLOW FOR LONG STRINGS!
+                raw = rline[cursor_pos:cursor_pos+maxsearch].split(None, 2)  # TODO: maybe slow for long strings -- hopefuly maxsearch helps
                 if line[cursor_pos] in line_seps:
                     raw.insert(0, "")
                 if len(raw) == 1:
@@ -1518,9 +1518,9 @@ class InstructionFile(object):
                         )
                     )
                 # step over current value
-                cursor_pos = rline.find(' ', cursor_pos) # cursor_pos + line[cursor_pos:].replace(",", " ").index(" ")  # TO#DO: SLOW FOR LONG STRINGS!
+                cursor_pos = rline.find(' ', cursor_pos)
                 # now find position of next entry
-                cursor_pos = rline.find(raw[1], cursor_pos)  # cursor_pos + line[cursor_pos:].replace(",", " ").index(  # TO#DO: SLOW FOR LONG STRINGS!
+                cursor_pos = rline.find(raw[1], cursor_pos)
                    # raw[1]
                # )
 
@@ -1539,7 +1539,7 @@ class InstructionFile(object):
                             )
                         )
                     # read to closing marker
-                    val_str = line[cursor_pos:es]  # .split(m, 1)[0]  # TO#DO SLOW
+                    val_str = line[cursor_pos: es]
                 else:
                     # find next space in (r)line -- signifies end of entry
                     es = rline.find(' ', cursor_pos)
@@ -1548,10 +1548,12 @@ class InstructionFile(object):
                         # use old fashioned split to get value
                         # -- this will happen if there are leading blanks before
                         # vals in output file (e.g. formatted)
-                        val_str = rline[cursor_pos:].split(None, 1)[0]
+                        val_str = rline[
+                                  cursor_pos: cursor_pos+maxsearch
+                                  ].split(None, 1)[0]
                     else:
                         # read val (constrained slice is faster for big strings)
-                        val_str = rline[cursor_pos: es]  # .replace(",", " ").split(None, 1)[0]  # TO#DO SLOW
+                        val_str = rline[cursor_pos: es]
                 try:
                     val = float(val_str)
                 except Exception as e:
@@ -1564,7 +1566,7 @@ class InstructionFile(object):
 
                 if oname != "dum":
                     val_dict[oname] = val
-                ipos = line.find(val_str.strip(), cursor_pos) # ].index(val_str.strip())  # TODO SLOW
+                ipos = line.find(val_str.strip(), cursor_pos)
                 # val_len = len(val_str)
                 cursor_pos = ipos + len(val_str)  # update cursor
                 all_markers = False
@@ -1631,7 +1633,7 @@ class InstructionFile(object):
                     )
 
                 ss_idx = max(cursor_pos, s_idx)
-                raw = line[ss_idx:].split(None, 1)  # slpitting only 1 might be margin faster
+                raw = line[ss_idx: ss_idx+maxsearch].split(None, 1)  # slpitting only 1 might be margin faster
                 rs_idx = line.index(raw[0])
                 if rs_idx > e_idx:
                     self.throw_out_error(
@@ -1759,8 +1761,8 @@ class InstructionFile(object):
             if len(first) > 0:
                 tokens.append(first)
             for idx in range(1, len(midx) - 1, 2):
-                mstr = line[midx[idx - 1] : midx[idx] + 1]
-                ostr = line[midx[idx] + 1 : midx[idx + 1]]
+                mstr = line[midx[idx - 1]: midx[idx] + 1]
+                ostr = line[midx[idx] + 1: midx[idx + 1]]
                 tokens.append(mstr)
                 tokens.extend(ostr.split())
         else:

--- a/pyemu/utils/pst_from.py
+++ b/pyemu/utils/pst_from.py
@@ -1225,7 +1225,8 @@ class PstFrom(object):
         use_cols_psd = copy.copy(use_cols)  # store passed use_cols argument
         if insfile is None: # setup instruction file name
             insfile = "{0}.ins".format(filename)
-        self.logger.log("adding observations from tabular output file")
+        self.logger.log("adding observations from output file "
+                        "{0}".format(filename))
         # precondition arguments
         (
             filenames,
@@ -1290,6 +1291,8 @@ class PstFrom(object):
             return new_obs
 
         # list style obs
+        self.logger.log("adding observations from tabular output file "
+                        "'{0}'".format(filenames))
         # -- will end up here if either of index_cols or use_cols is not None
         df, storehead = self._load_listtype_file(
             filenames, index_cols, use_cols, fmts, seps, skip_rows
@@ -1387,7 +1390,8 @@ class PstFrom(object):
                 new_obs.loc[:, "obgnme"] = df_ins.loc[new_obs.index, "obgnme"]
             new_obs_l.append(new_obs)
         new_obs = pd.concat(new_obs_l)
-        self.logger.log("adding observations from tabular output file")
+        self.logger.log("adding observations from tabular output file "
+                        "'{0}'".format(filenames))
         if rebuild_pst:
             if self.pst is not None:
                 self.logger.log("Adding obs to control file " "and rewriting pst")

--- a/pyemu/utils/pst_from.py
+++ b/pyemu/utils/pst_from.py
@@ -1302,7 +1302,7 @@ class PstFrom(object):
             index_cols = df.iloc[0][index_cols].to_list()  # redefine index_cols
             if use_cols is not None:
                 use_cols = df.iloc[0][use_cols].to_list()  # redefine use_cols
-            df = df.rename(columns=df.iloc[0]).drop(0).reset_index(drop=True).apply(pd.to_numeric)
+            df = df.rename(columns=df.iloc[0].to_dict()).drop(0).reset_index(drop=True).apply(pd.to_numeric, errors='ignore')
         # Select all non index cols if use_cols is None
         if use_cols is None:
             use_cols = df.columns.drop(index_cols).tolist()
@@ -2524,7 +2524,8 @@ class PstFrom(object):
                     if line.strip().startswith(c_char)
                 }
         df = pd.read_csv(
-            file_path, comment=c_char, sep=sep, skiprows=skip, header=header
+            file_path, comment=c_char, sep=sep, skiprows=skip, header=header,
+            low_memory=False
         )
         self.logger.log("reading list {0}".format(file_path))
         # ensure that column ids from index_col is in input file

--- a/pyemu/utils/pst_from.py
+++ b/pyemu/utils/pst_from.py
@@ -941,7 +941,7 @@ class PstFrom(object):
             call_str (`str`): the call string for python function in
                 `file_name`.
                 `call_str` will be added to the forward run script, as is.
-            is_pre_cmd (`bool`): flag to include `call_str` in
+            is_pre_cmd (`bool` or `None`): flag to include `call_str` in
                 PstFrom.pre_py_cmds.  If False, `call_str` is
                 added to PstFrom.post_py_cmds instead. If passed as `None`,
                 then the function `call_str` is added to the forward run


### PR DESCRIPTION
Following on from #238. Trying to speed up processing output files (adding observations with PstFrom()).

Among other attempts for efficiency this PR aims to reduce and speed up the calls to slice long output files lines (e.g. `line[cursor_pos:]`). Using `line.find(str, cursor_pos)` where appropriate and a `maxsearch` length to reduce the length of copied string when slicing. 

Added to pst_from_test to test a big file. Would be nice to add a timeout to this somehow -- but I am not sure how to do that.