### PR TITLE
weightless metrics for goodness of fit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
               "full_meal_deal_tests.py", 
               "la_tests.py", 
               "plot_tests.py", 
+              "metrics_tests.py",
               "moouu_tests.py", 
               "mat_tests.py", 
               "da_tests.py"

--- a/autotest/metrics_tests.py
+++ b/autotest/metrics_tests.py
@@ -1,0 +1,67 @@
+
+def res_and_ens_test():
+    import pandas as pd
+    import numpy as np
+    import pyemu
+
+    # make some fake residuals
+    np.random.seed(42)
+    t = np.linspace(1,20, 200)
+    obs = t/10 * np.sin(np.pi*t)
+    mod = obs+np.random.randn(200)*.5    
+    obsnames = ['ob_t_{:03d}'.format(i) for i in range(len(t))]
+    obsgroups = ['start_grp' if i<80 else 'end_grp' for i in range(len(t))]
+    res = pd.DataFrame({'name':obsnames,
+                        'group':obsgroups,
+                        'measured':obs,
+                        'modelled':mod,
+                        'residual':obs-mod,
+                        'weight':np.ones(len(t))})
+    res.set_index(res['name'], inplace=True)
+    np.random.seed(98)
+    res.weight =  [float(i>.5) for i in np.random.random(200)]
+
+    # and an ensemble version
+    ens = pd.DataFrame(np.tile(obs,(10,1))+np.random.randn(10,200)*.5, columns=obsnames)
+    ens.loc['base'] = mod
+
+    # cook up a PEST file for obs and weights
+    pst = pyemu.pst_utils.generic_pst(obs_names=obsnames)
+    pst.observation_data['obsval'] = obs
+    pst.observation_data['obsname'] = obsnames    
+
+    pst.observation_data['weight'] = res.weight.values
+    pst.observation_data['obgnme'] = obsgroups
+
+    all_met_res_groups = pyemu.metrics.calc_metric_res(res)
+    all_met_res_nodrop = pyemu.metrics.calc_metric_res(res, drop_zero_weight=False)
+    all_met_res = pyemu.metrics.calc_metric_res(res, drop_zero_weight=False,bygroups=False)
+
+    all_met_ens_groups = pyemu.metrics.calc_metric_ensemble(ens,pst)
+    all_met_ens_nodrop = pyemu.metrics.calc_metric_ensemble(ens,pst, drop_zero_weight=False)
+    all_met_ens = pyemu.metrics.calc_metric_ensemble(ens,pst, drop_zero_weight=False,bygroups=False)
+
+    # make sure all the metrics match since 'base' in ens is same as single real in res
+    assert all(all_met_ens.loc['base'].values == all_met_res.loc['single_realization'].values)
+    assert all(all_met_ens_nodrop[all_met_ens_nodrop.columns].loc['base'].values == 
+        all_met_res_nodrop[all_met_ens_nodrop.columns].loc['single_realization'].values)    
+    assert all(all_met_ens_groups[all_met_ens_groups.columns].loc['base'].values == 
+        all_met_res_groups[all_met_ens_groups.columns].loc['single_realization'].values)
+
+    # test the functions - first the athens test (do they run?)
+    fcns = pyemu.metrics.ALLMETRICS
+    results = [fcns[i](mod,obs) for i in fcns]
+    assert len(results) == len(fcns)
+
+    # now spot check a couple obvious values
+    m=np.array(range(100))
+    o=np.array(range(100))
+    assert fcns['nse'](m,o) == 1.0
+    assert fcns['rmse'](m,o) == 0.0
+    assert fcns['mse'](m,o) == 0.0
+    assert fcns['mae'](m,o) == 0.0
+    assert fcns['pbias'](m,o) == 0.0
+    assert fcns['kge'](m,o) == 1.0
+    
+if __name__ == "__main__":
+    res_and_ens_test()

--- a/pyemu/__init__.py
+++ b/pyemu/__init__.py
@@ -24,6 +24,7 @@ from .utils import (
     pp_utils,
     os_utils,
     smp_utils,
+    metrics
 )
 from .plot import plot_utils
 from .logger import Logger
@@ -52,5 +53,6 @@ __all__ = [
     "os_utils",
     "smp_utils",
     "plot_utils",
+    "metrics"
 ]
 # del get_versions

--- a/pyemu/utils/__init__.py
+++ b/pyemu/utils/__init__.py
@@ -11,3 +11,4 @@ from .gw_utils import *
 from .os_utils import *
 from .smp_utils import *
 from .pst_from import *
+from .metrics import *

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -476,7 +476,9 @@ def calc_observation_ensemble_quantiles(
 
 
 def calc_rmse_ensemble(ens, pst, bygroups=True, subset_realizations=None):
-    """Calculates RMSE (without weights) to quantify fit to observations for ensemble members
+    """
+    DEPRECATED -->please see pyemu.utils.metrics.calc_metric_ensemble() 
+    Calculates RMSE (without weights) to quantify fit to observations for ensemble members
 
     Args:
         ens (pandas DataFrame): DataFrame read from an observation
@@ -489,39 +491,7 @@ def calc_rmse_ensemble(ens, pst, bygroups=True, subset_realizations=None):
         **pandas.DataFrame**: rows are realizations. Columns are groups. Content is RMSE
     """
 
-    # TODO: handle zero weights due to PDC
-
-    # make sure subset_realizations is a list
-    if not isinstance(subset_realizations, list) and subset_realizations is not None:
-        subset_realizations = list(subset_realizations)
-
-    if "real_name" in ens.columns:
-        ens.set_index("real_name")
-    if not isinstance(pst, pyemu.Pst):
-        raise Exception("pst object must be of type pyemu.Pst")
-
-    # get the observation data
-    obs = pst.observation_data.copy()
-
-    # confirm that the indices and observations line up
-    if False in np.unique(ens.columns == obs.index):
-        raise Exception("ens and pst observation names do not align")
-
-    rmse = pd.DataFrame(index=ens.index)
-    if subset_realizations is not None:
-        rmse = rmse.loc[subset_realizations]
-
-    # calculate the rmse total first
-    rmse["total"] = [_rmse(ens.loc[i], obs.obsval) for i in rmse.index]
-
-    # if bygroups, do the groups as columns
-    if bygroups is True:
-        for cg in obs.obgnme.unique():
-            cnames = obs.loc[obs.obgnme == cg].obsnme
-            rmse[cg] = [
-                _rmse(ens.loc[i][cnames], obs.loc[cnames].obsval) for i in rmse.index
-            ]
-    return rmse
+    raise Exception('this is deprecated-->please see pyemu.utils.metrics.calc_metric_ensemble()')
 
 
 def _condition_on_par_knowledge(cov, var_knowledge_dict):

--- a/pyemu/utils/metrics.py
+++ b/pyemu/utils/metrics.py
@@ -1,0 +1,239 @@
+import pandas as pd
+import numpy as np
+import pyemu
+
+# lowest level functions
+# see https://pypi.org/project/hydroeval/#files for example implementation which were consulted
+def _NSE(obs, mod):
+    '''
+    Calculate the Nash-Sutcliffe Efficiency
+    (https://www.sciencedirect.com/science/article/pii/0022169470902556?via%3Dihub)
+    Args:
+        obs: numpy array of observed values
+        mod: numpy array of modeled values
+
+    Returns:
+        NSE: Nash-Sutcliffe Efficiency
+
+
+    '''
+    return 1-(np.sum((obs-mod)**2) / np.sum((obs-np.mean(obs))**2))
+
+def _NNSE(obs, mod):
+    '''
+    Calculate the Normalized Nash-Sutcliffe Efficiency
+    (https://meetingorganizer.copernicus.org/EGU2012/EGU2012-237.pdf)
+    Args:
+        obs: numpy array of observed values
+        mod: numpy array of modeled values
+
+    Returns:
+        NSE: Nash-Sutcliffe Efficiency
+
+
+    '''
+    return 1/(2-_NSE(obs,mod))
+
+def _MAE(mod, obs):
+    '''
+    Calculate the Mean Absolute Error
+    Args:
+        obs: numpy array of observed values
+        mod: numpy array of modeled values
+
+    Returns:
+        MAE: Mean Absolute Error
+    '''
+    return np.mean(np.abs(obs-mod))
+
+def _MSE(mod, obs):
+    '''
+    Calculate the Mean Squared Error
+    Args:
+        obs: numpy array of observed values
+        mod: numpy array of modeled values
+
+    Returns:
+        MSE: Mean Squared Error
+    '''
+    return np.mean(np.sum((obs-mod)**2))
+
+def _RMSE(mod, obs):
+    '''
+    Calculate the Root Mean Squared Error
+    Args:
+        obs: numpy array of observed values
+        mod: numpy array of modeled values
+
+    Returns:
+        RMSE: Root Mean Squared Error
+    '''
+    return np.sqrt(_MSE(obs,mod))
+
+def _PBIAS(mod, obs):
+    '''
+    Calculate the percent bias
+    Args:
+        obs: numpy array of observed values
+        mod: numpy array of modeled values
+
+    Returns:
+        PBIAS: Percent Bias
+    '''
+    return 100 * ((np.sum(mod-obs)) / (np.sum(obs)))
+
+def _KGE(mod, obs):
+    '''
+    Calculate the Kling-Gupta Efficiency (KGE)
+    (https://www.sciencedirect.com/science/article/pii/S0022169409004843)
+    Args:
+        obs: numpy array of observed values
+        mod: numpy array of modeled values
+
+    Returns:
+        KGE: Kling-Gupta Efficiency
+    '''
+    obsmean = np.mean(obs)
+    modmean = np.mean(mod)
+    d_obs = obs-obsmean
+    d_mod = mod-modmean
+    r = np.sum(d_obs * d_mod) / np.sqrt( np.sum(d_mod**2) * np.sum(d_obs**2))
+    alpha = np.std(mod)/np.std(obs)
+    beta = np.sum(mod) / np.sum(obs)
+
+    ED = np.sqrt((r - 1)**2 + (alpha - 1)**2 + (beta - 1)**2)
+    return 1 - ED
+
+
+# available metrics to calculate
+ALLMETRICS = {'pbias':_PBIAS, 
+                'rmse':_RMSE,
+                'mse':_MSE,
+                'nse':_NSE,
+                'nnse':_NNSE,
+                'mae':_MAE,
+                'kge':_KGE}
+
+def calc_metric_res(res, metric='all', bygroups=True, drop_zero_weight=True):
+    """Calculates unweighted metrics to quantify fit to observations for residuals
+
+    Args:
+        res (pandas DataFrame or filename): DataFrame read from a residuals file or filename 
+        metric (list of str): metric to calculate (PBIAS, RMSE, MSE, NSE, MAE) case insensitive
+            Defaults to 'all' which calculates all available metrics
+        bygroups (Bool): Flag to summarize by groups or not. Defaults to True.
+        drop_zero_weight (Bool): flag to exclude zero-weighted observations
+
+    Returns:
+        **pandas.DataFrame**: single row. Columns are groups. Content is requested metrics
+    """    
+    # check that metrics are a list - if 'all' calculate for them all 
+    if isinstance(metric, str):
+        if metric.lower()=='all':
+            metric = list(ALLMETRICS.keys())
+        else:
+            metric = list(metric)
+    missing_metrics = ()
+    for cm in metric:
+        if cm.lower() not in ALLMETRICS:
+            missing_metrics.append(cm)
+    if len(missing_metrics) > 0:
+        raise Exception('Requested metrics: {} not implemented'.format(' '.join(missing_metrics)))
+    
+    # sort out the res arg to be a file (to read) or already a dataframe
+    if isinstance(res, str):
+        try:
+            res = pyemu.pst_utils.read_resfile(res)
+        except:
+            raise Exception('{} is not a valid file path'.format(res))
+    elif not isinstance(res, pd.DataFrame):
+            raise Exception('{} must be either a valid file path or a residuals dataframe'.format(res))
+
+    if drop_zero_weight:
+        res = res.loc[res.weight != 0]
+
+    ret_df = pd.DataFrame(index=['single_realization'])
+
+    # calculate the rmse total first
+    for cm in metric:
+        f = ALLMETRICS[cm.lower()]
+        ret_df["{}_total".format(cm.upper())] = [f(res.modelled, res.measured) for i in ret_df.index]
+
+        # if bygroups, do the groups as columns
+        if bygroups is True:
+            for cn, cg in res.groupby('group'):
+                ret_df["{}_{}".format(cm.upper(), cn)] = f(cg.modelled, cg.measured)
+    return ret_df
+
+def calc_metric_ensemble(ens, pst, metric='all', bygroups=True, subset_realizations=None, drop_zero_weight=True):
+    """Calculates unweighted metrics to quantify fit to observations for ensemble members
+
+    Args:
+        ens (pandas DataFrame): DataFrame read from an observation
+        pst (pyemu.Pst object):  needed to obtain observation values and weights
+        metric (list of str): metric to calculate (PBIAS, RMSE, MSE, NSE, MAE) case insensitive
+            Defaults to 'all' which calculates all available metrics
+        bygroups (Bool): Flag to summarize by groups or not. Defaults to True.
+        subset_realizations (iterable, optional): Subset of realizations for which
+                to report metric. Defaults to None which returns all realizations.
+        drop_zero_weight (Bool): flag to exclude zero-weighted observations
+    Returns:
+        **pandas.DataFrame**: rows are realizations. Columns are groups. Content is requested metrics
+    """
+
+
+    # TODO: handle zero weights due to PDC
+    # check that metrics are a list - if 'all' calculate for them all 
+    if isinstance(metric, str):
+        if metric.lower()=='all':
+            metric = list(ALLMETRICS.keys())
+        else:
+            metric = list(metric)
+    missing_metrics = ()
+    for cm in metric:
+        if cm.lower() not in ALLMETRICS:
+            missing_metrics.append(cm)
+    if len(missing_metrics) > 0:
+        raise Exception('Requested metrics: {} not implemented'.format(' '.join(missing_metrics)))
+
+    # make sure subset_realizations is a list
+    if not isinstance(subset_realizations, list) and subset_realizations is not None:
+        subset_realizations = list(subset_realizations)
+
+    if "real_name" in ens.columns:
+        ens.set_index("real_name", inplace=True)
+
+    if not isinstance(pst, pyemu.Pst):
+        raise Exception("pst object must be of type pyemu.Pst")
+
+    # get the observation data
+    obs = pst.observation_data.copy()
+
+    # confirm that the indices and observations line up
+    if False in np.unique(ens.columns == obs.index):
+        raise Exception("ens and pst observation names do not align")
+
+    if drop_zero_weight:
+        # subset to only include non-zero-weighted obs
+        ens = ens[pst.nnz_obs_names]
+        obs = obs.loc[pst.nnz_obs_names]
+
+    ret_df = pd.DataFrame(index=ens.index)
+    if subset_realizations is not None:
+        ret_df = ret_df.loc[subset_realizations]
+
+    # calculate the rmse total first
+    for cm in metric:
+        f = ALLMETRICS[cm.lower()]
+        ret_df["{}_total".format(cm.upper())] = [f(ens.loc[i], obs.obsval) for i in ret_df.index]
+
+        # if bygroups, do the groups as columns
+        if bygroups is True:
+            for cg in obs.obgnme.unique():
+                cnames = obs.loc[obs.obgnme == cg].obsnme
+                ret_df["{}_{}".format(cm.upper(),cg)] = [
+                    f(ens.loc[i][cnames], obs.loc[cnames].obsval) for i in ret_df.index
+                ]
+    return ret_df
+
+        

--- a/pyemu/utils/metrics.py
+++ b/pyemu/utils/metrics.py
@@ -56,7 +56,7 @@ def _MSE(mod, obs):
     Returns:
         MSE: Mean Squared Error
     '''
-    return np.mean(np.sum((obs-mod)**2))
+    return np.mean((obs-mod)**2)
 
 def _RMSE(mod, obs):
     '''


### PR DESCRIPTION
Added a metrics package and tests for goodness of fit metrics without weights. options to group by obs groups and to include/exclude 0 weighted obs. Also supports RES files and ensembles (ensembles require a PST file as well). Can add functions through a dictionary called `ALLMETRICS` in `pyemu/utils/metrics.py`.