### PR TITLE
Dealing with some deprecations

### DIFF
--- a/autotest/pst_from_tests.py
+++ b/autotest/pst_from_tests.py
@@ -122,8 +122,8 @@ def freyberg_test():
                       "Processed into tabular form using the lines:\n",
                       "sfo = flopy.utils.SfrFile('freyberg.sfr.out')\n",
                       "sfo.get_dataframe().to_csv('freyberg.sfo.dat')\n"])
-        sfodf.sort_index(1).to_csv(fp, sep=' ', index_label='idx',line_terminator='\n')
-    sfodf.sort_index(1).to_csv(os.path.join(m.model_ws, 'freyberg.sfo.csv'),
+        sfodf.sort_index(axis=1).to_csv(fp, sep=' ', index_label='idx',line_terminator='\n')
+    sfodf.sort_index(axis=1).to_csv(os.path.join(m.model_ws, 'freyberg.sfo.csv'),
                  index_label='idx',line_terminator='\n')
     template_ws = "new_temp"
     # sr0 = m.sr
@@ -186,7 +186,7 @@ def freyberg_test():
          "'Processed into tabular form using the lines:\\n', "
          "'sfo = flopy.utils.SfrFile(`freyberg.sfr.out`)\\n', "
          "'sfo.get_dataframe().to_csv(`freyberg.sfo.dat`)\\n'])",
-         "    sfodf.sort_index(1).to_csv(fp, sep=' ', index_label='idx',line_terminator='\\n')"])
+         "    sfodf.sort_index(axis=1).to_csv(fp, sep=' ', index_label='idx',line_terminator='\\n')"])
     # csv version of sfr obs
     # sfr outputs to obs
     pf.add_observations('freyberg.sfo.csv', insfile=None,
@@ -212,7 +212,7 @@ def freyberg_test():
     obsnmes = pd.concat([df.obgnme for df in pf.obs_dfs]).unique()
     assert all([gp in obsnmes for gp in ['qaquifer', 'qout']])
     pf.post_py_cmds.append(
-        "sfodf.sort_index(1).to_csv('freyberg.sfo.csv', sep=',', index_label='idx')")
+        "sfodf.sort_index(axis=1).to_csv('freyberg.sfo.csv', sep=',', index_label='idx')")
     zone_array = np.arange(m.nlay*m.nrow*m.ncol)
     s = lambda x: "zval_"+str(x)
     zone_array = np.array([s(x) for x in zone_array]).reshape(m.nlay,m.nrow,m.ncol)
@@ -573,7 +573,7 @@ def mf6_freyberg_test():
     os.mkdir(tmp_model_ws)
     sim = flopy.mf6.MFSimulation.load(sim_ws=org_model_ws)
     # sim.set_all_data_external()
-    sim.simulation_data.mfpath.set_sim_path(tmp_model_ws)
+    sim.set_sim_path(tmp_model_ws)
     # sim.set_all_data_external()
     m = sim.get_model("freyberg6")
     sim.set_all_data_external(check_data=False)
@@ -964,7 +964,7 @@ def mf6_freyberg_shortnames_test():
     # os.mkdir(tmp_model_ws)
     # sim = flopy.mf6.MFSimulation.load(sim_ws=org_model_ws)
     # # sim.set_all_data_external()
-    # sim.simulation_data.mfpath.set_sim_path(tmp_model_ws)
+    # sim.set_sim_path(tmp_model_ws)
     # # sim.set_all_data_external()
     # m = sim.get_model("freyberg6")
     # sim.set_all_data_external()
@@ -1306,7 +1306,7 @@ def mf6_freyberg_direct_test():
     os.mkdir(tmp_model_ws)
     sim = flopy.mf6.MFSimulation.load(sim_ws=org_model_ws)
     # sim.set_all_data_external()
-    sim.simulation_data.mfpath.set_sim_path(tmp_model_ws)
+    sim.set_sim_path(tmp_model_ws)
     # sim.set_all_data_external()
     m = sim.get_model("freyberg6")
     sim.set_all_data_external()
@@ -1661,7 +1661,7 @@ def mf6_freyberg_varying_idomain():
     os.mkdir(tmp_model_ws)
     sim = flopy.mf6.MFSimulation.load(sim_ws=org_model_ws)
     # sim.set_all_data_external()
-    sim.simulation_data.mfpath.set_sim_path(tmp_model_ws)
+    sim.set_sim_path(tmp_model_ws)
     # sim.set_all_data_external()
     m = sim.get_model("freyberg6")
     sim.set_all_data_external(check_data=False)
@@ -1871,7 +1871,7 @@ def mf6_freyberg_short_direct_test():
     os.mkdir(tmp_model_ws)
     sim = flopy.mf6.MFSimulation.load(sim_ws=org_model_ws)
     # sim.set_all_data_external()
-    sim.simulation_data.mfpath.set_sim_path(tmp_model_ws)
+    sim.set_sim_path(tmp_model_ws)
     # sim.set_all_data_external()
     m = sim.get_model("freyberg6")
     sim.set_all_data_external()
@@ -2908,7 +2908,7 @@ def mf6_freyberg_pp_locs_test():
     os.mkdir(tmp_model_ws)
     sim = flopy.mf6.MFSimulation.load(sim_ws=org_model_ws)
     # sim.set_all_data_external()
-    sim.simulation_data.mfpath.set_sim_path(tmp_model_ws)
+    sim.set_sim_path(tmp_model_ws)
     # sim.set_all_data_external()
     m = sim.get_model("freyberg6")
     sim.set_all_data_external(check_data=False)
@@ -3230,7 +3230,7 @@ def mf6_add_various_obs_test():
     os.mkdir(tmp_model_ws)
     sim = flopy.mf6.MFSimulation.load(sim_ws=org_model_ws)
     # sim.set_all_data_external()
-    sim.simulation_data.mfpath.set_sim_path(tmp_model_ws)
+    sim.set_sim_path(tmp_model_ws)
     # sim.set_all_data_external()
     m = sim.get_model("freyberg6")
     sim.set_all_data_external(check_data=False)
@@ -3322,7 +3322,7 @@ def mf6_subdir_test():
     tmp2_ws = os.path.join(tmp_model_ws, sd)
     sim = flopy.mf6.MFSimulation.load(sim_ws=org_model_ws)
     # sim.set_all_data_external()
-    sim.simulation_data.mfpath.set_sim_path(tmp2_ws)
+    sim.set_sim_path(tmp2_ws)
     # sim.set_all_data_external()
     m = sim.get_model("freyberg6")
     sim.set_all_data_external(check_data=False)
@@ -3617,24 +3617,24 @@ def mf6_subdir_test():
 if __name__ == "__main__":
     #mf6_freyberg_pp_locs_test()
     # invest()
-    freyberg_test()
+    # freyberg_test()
     #freyberg_prior_build_test()
-    # mf6_freyberg_test()
+    mf6_freyberg_test()
     #$mf6_freyberg_da_test()
     # mf6_freyberg_shortnames_test()
 
     #mf6_freyberg_direct_test()
     #mf6_freyberg_varying_idomain()
     # xsec_test()
-    mf6_freyberg_short_direct_test()
+    # mf6_freyberg_short_direct_test()
     # mf6_add_various_obs_test()
     # mf6_subdir_test()
-    tpf = TestPstFrom()
-    tpf.setup()
+    # tpf = TestPstFrom()
+    # tpf.setup()
     #tpf.test_add_array_parameters_to_file_list()
     #tpf.test_add_array_parameters_alt_inst_str_none_m()
     #tpf.test_add_array_parameters_alt_inst_str_0_d()
-    tpf.test_add_array_parameters_pps_grid()
+    # tpf.test_add_array_parameters_pps_grid()
     # # pstfrom_profile()
     #mf6_freyberg_arr_obs_and_headerless_test()
     #usg_freyberg_test()

--- a/autotest/pst_tests.py
+++ b/autotest/pst_tests.py
@@ -1279,7 +1279,7 @@ if __name__ == "__main__":
     # rectify_pgroup_test()
     #sanity_check_test()
     #change_limit_test()
-    #write_tables_test()
+    write_tables_test()
     #pi_helper_test()
     #ctrl_data_test()
     #new_format_test_2()
@@ -1289,7 +1289,7 @@ if __name__ == "__main__":
     #comments_test()
     #read_in_tpl_test()
     #read_in_tpl_test2()
-    tied_test()
+    # tied_test()
 
     #comments_test()
     #csv_to_ins_test()

--- a/autotest/pst_tests.py
+++ b/autotest/pst_tests.py
@@ -1239,7 +1239,7 @@ def rename_obs_test():
 
 if __name__ == "__main__":
     
-    write2_nan_test()
+    # write2_nan_test()
     #process_output_files_test()
     # change_limit_test()
     # new_format_test()
@@ -1289,7 +1289,7 @@ if __name__ == "__main__":
     #comments_test()
     #read_in_tpl_test()
     #read_in_tpl_test2()
-    #tied_test()
+    tied_test()
 
     #comments_test()
     #csv_to_ins_test()

--- a/pyemu/pst/pst_handler.py
+++ b/pyemu/pst/pst_handler.py
@@ -1345,8 +1345,9 @@ class Pst(object):
             defaults = copy.copy(pst_utils.pst_config["pargp_defaults"])
             for grp in need_groups:
                 defaults["pargpnme"] = grp
-                self.parameter_groups = self.parameter_groups.append(
-                    defaults, ignore_index=True
+                self.parameter_groups = pd.concat(
+                    [self.parameter_groups, pd.DataFrame([defaults])],
+                    ignore_index=True
                 )
 
         # now drop any left over groups that aren't needed

--- a/pyemu/pst/pst_handler.py
+++ b/pyemu/pst/pst_handler.py
@@ -3393,9 +3393,12 @@ class Pst(object):
                 f.write(preamble)
                 f.write("\\begin{center}\nParameter Summary\n\\end{center}\n")
                 f.write("\\begin{center}\n\\begin{landscape}\n")
-                f.write(pargp_df.style.hide(axis='index').to_latex(
-                    None, environment='longtable')
-                )
+                try:
+                    f.write(pargp_df.style.hide(axis='index').to_latex(
+                        None, environment='longtable')
+                    )
+                except (TypeError, AttributeError) as e:
+                    pargp_df.to_latex(index=False, longtable=True)
                 f.write("\\end{landscape}\n")
                 f.write("\\end{center}\n")
                 f.write("\\end{document}\n")
@@ -3510,9 +3513,12 @@ class Pst(object):
                 f.write("\\begin{center}\nObservation Summary\n\\end{center}\n")
                 f.write("\\begin{center}\n\\begin{landscape}\n")
                 f.write("\\setlength{\\LTleft}{-4.0cm}\n")
-                f.write(obsg_df.style.hide(axis='index').to_latex(
-                    None, environment='longtable')
-                )
+                try:
+                    f.write(obsg_df.style.hide(axis='index').to_latex(
+                        None, environment='longtable')
+                    )
+                except (TypeError, AttributeError) as e:
+                    obsg_df.to_latex(index=False, longtable=True)
                 f.write("\\end{landscape}\n")
                 f.write("\\end{center}\n")
                 f.write("\\end{document}\n")

--- a/pyemu/pst/pst_handler.py
+++ b/pyemu/pst/pst_handler.py
@@ -2841,7 +2841,7 @@ class Pst(object):
                 pst_utils.pst_config["par_dtype"],
             )
             new_par_data.loc[new_parnme, "parnme"] = new_parnme
-            self.parameter_data = self.parameter_data.append(new_par_data)
+            self.parameter_data = pd.concat([self.parameter_data, new_par_data])
             if parval1 is not None:
                 new_par_data.loc[parval1.parnme, "parval1"] = parval1.parval1
         if in_file is None:
@@ -3063,7 +3063,7 @@ class Pst(object):
         )
         new_obs_data.loc[obsnme, "obsnme"] = obsnme
         new_obs_data.index = obsnme
-        self.observation_data = self.observation_data.append(new_obs_data)
+        self.observation_data = pd.concat([self.observation_data, new_obs_data])
         cwd = "."
         if pst_path is not None:
             cwd = os.path.join(*os.path.split(ins_file)[:-1])
@@ -3393,7 +3393,9 @@ class Pst(object):
                 f.write(preamble)
                 f.write("\\begin{center}\nParameter Summary\n\\end{center}\n")
                 f.write("\\begin{center}\n\\begin{landscape}\n")
-                pargp_df.to_latex(f, index=False, longtable=True)
+                f.write(pargp_df.style.hide(axis='index').to_latex(
+                    None, environment='longtable')
+                )
                 f.write("\\end{landscape}\n")
                 f.write("\\end{center}\n")
                 f.write("\\end{document}\n")
@@ -3508,7 +3510,9 @@ class Pst(object):
                 f.write("\\begin{center}\nObservation Summary\n\\end{center}\n")
                 f.write("\\begin{center}\n\\begin{landscape}\n")
                 f.write("\\setlength{\\LTleft}{-4.0cm}\n")
-                obsg_df.to_latex(f, index=False, longtable=True)
+                f.write(obsg_df.style.hide(axis='index').to_latex(
+                    None, environment='longtable')
+                )
                 f.write("\\end{landscape}\n")
                 f.write("\\end{center}\n")
                 f.write("\\end{document}\n")

--- a/pyemu/utils/geostats.py
+++ b/pyemu/utils/geostats.py
@@ -1450,7 +1450,7 @@ class OrdinaryKrige(object):
             if self.interp_data is None:
                 self.interp_data = df
             else:
-                self.interp_data = self.interp_data.append(df)
+                self.interp_data = pd.concat([self.interp_data, df])
         # correct for negative kriging factors, if requested
         if remove_negative_factors == True:
             self._remove_neg_factors()

--- a/pyemu/utils/gw_utils.py
+++ b/pyemu/utils/gw_utils.py
@@ -279,7 +279,7 @@ def setup_mtlist_budget_obs(
         df_sw = try_process_output_file(sw_ins, sw_filename)
         if df_sw is None:
             raise Exception("error processing surface water instruction file")
-        df_gw = df_gw.append(df_sw)
+        df_gw = pd.concat([df_gw, df_sw])
         df_gw.loc[:, "obsnme"] = df_gw.index.values
     if save_setup_file:
         df_gw.to_csv("_setup_" + os.path.split(list_filename)[-1] + ".csv", index=False)

--- a/pyemu/utils/gw_utils.py
+++ b/pyemu/utils/gw_utils.py
@@ -426,7 +426,7 @@ def setup_mflist_budget_obs(
     if df2 is None:
         raise Exception("error processing volume instruction file")
 
-    df = df.append(df2)
+    df = pd.concat([df, df2])
     df.loc[:, "obsnme"] = df.index.values
     if save_setup_file:
         df.to_csv("_setup_" + os.path.split(list_filename)[-1] + ".csv", index=False)
@@ -1506,8 +1506,7 @@ def setup_sfr_seg_parameters(
         else:
             seg_data.loc[:, par_col] = (
                 seg_data_all_kper.loc[:, (slice(None), par_col)]
-                .abs()
-                .max(level=1, axis=1)
+                    .abs().groupby(level=1, axis=1).max()
             )
     if len(missing) > 0:
         warnings.warn(
@@ -1615,7 +1614,7 @@ def setup_sfr_seg_parameters(
         if not tmp_df.empty:
             tmp_df.loc[:, "org_value"] = 1.0
             tmp_df.loc[:, "tpl_str"] = tmp_tpl_str
-            df = df.append(tmp_df[df.columns])
+            df = pd.concat([df, tmp_df[df.columns]])
     if df.empty:
         warnings.warn(
             "No sfr segment parameters have been set up, "


### PR DESCRIPTION
Making a few changes to deal with some future warnings and deprecations.
* flopy sensibly now has path change on the sim object. 
* pandas is deprecating df.append in favour of pd.concat
* Pandas also dropping df.to_latex() in favour of the use of their own Styler. This seems to be changing and was giving errors in py3.7 so some backward compat retained for now.