### PR TITLE
Use pyproject.toml to describe build system and project metadata

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,5 @@ dist/* linguist-vendored=true
 doc/* linguist-vendored=true
 build/* linguist-vendored=true
 misc/* linguist-vendored=true
-verification/* linguist-vendored=truepyemu/_version.py export-subst
+verification/* linguist-vendored=true
 pyemu/_version.py export-subst

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,22 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.8
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@ import os
 import sys
 sys.path.insert(0, os.path.join('..','pyemu'))
 sys.path.append(os.path.join(".."))
+from pyemu import __version__
 
 
 
@@ -22,7 +23,7 @@ sys.path.append(os.path.join(".."))
 project = 'pyEMU'
 copyright = '2020, Jeremy White, Mike Fienen, Brioch Hemmings, and others'
 author = 'Jeremy White, Mike Fienen, Brioch Hemmings, and others'
-release = "1.2.0"
+release = __version__
 
 # -- General configuration ---------------------------------------------------
 
@@ -39,6 +40,7 @@ extensions.append('autoapi.extension')
 
 autoapi_type = 'python'
 autoapi_dirs = [os.path.join('..','pyemu')]
+autoapi_ignore = ['*version*']
 
 
 # Add any paths that contain templates here, relative to this directory.
@@ -60,4 +62,4 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']

--- a/docs/requirements.rtd.txt
+++ b/docs/requirements.rtd.txt
@@ -1,4 +1,0 @@
-numpy>=1.9
-pandas>=0.18.1
-pyshp
-autoapi

--- a/new_version_steps.txt
+++ b/new_version_steps.txt
@@ -3,6 +3,6 @@
 1.5) make sure version is updated in setup.py
 2) tag new version in master branch
 2.5) remove any existing dist, build, egg, etc
-3) python setup.py sdist bdist_wheel
+3) python -m build
 4) twine upload dist/* (pip install twine, not conda)
 5) update README.md to point to build and coverage status for master

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,58 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pyemu"
+dynamic = ["version"]
+authors = [
+    {name = "Jeremy White", email = "jtwhite1000@gmail.com"},
+    {name = "Mike Fienen", email = "mnfienen@usgs.gov"},
+    {name = "Brioch Hemmings", email = "b.hemmings@gns.cri.nz"},
+]
+description = "pyEMU is a set of python modules for interfacing with PEST and PEST++"
+readme = "README.md"
+keywords = ["pest", "pestpp"]
+license = {text = "BSD 3-Clause"}
+classifiers = [
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Scientific/Engineering :: Hydrology",
+]
+requires-python = ">=3.7"
+dependencies = [
+    "numpy",
+    "pandas",
+]
+
+[project.optional-dependencies]
+optional = [
+    "flopy",
+    "matplotlib",
+    "pyshp",
+    "scipy",
+]
+test = [
+    "coverage",
+    "coveralls",
+    "nose",
+    "nose-timer",
+]
+docs = [
+    "pyemu[optional]",
+    "sphinx >=3.2.1",
+    "sphinx-autoapi",
+    "sphinx-rtd-theme",
+]
+
+[project.urls]
+documentation = "https://pyemu.readthedocs.io/"
+repository = "https://github.com/pypest/pyemu"
+
+[tool.setuptools.packages.find]
+include = [
+    "pyemu",
+    "pyemu.*",
+]
+

--- a/requirements.travis.txt
+++ b/requirements.travis.txt
@@ -1,6 +1,0 @@
-numpy>=1.9
-pandas>=0.18.1
-pyshp
-codecov
-coverage
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-numpy>=1.9
-pandas>=0.18.1
-pyshp

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[versioneer]
+VCS = git
+style = pep440
+versionfile_source = pyemu/_version.py
+versionfile_build = pyemu/_version.py
+tag_prefix =

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,14 @@
+import os
 import sys
-#from distutils.core import setup
+
 from setuptools import setup
 
-long_description = "pyemu is a set of python modules for interfacing with PEST and PEST++. "
+sys.path.append(os.path.dirname(__file__))
 
-setup(name="pyemu",
-      description=long_description,
-      long_description=long_description,      
-      author="Jeremy White, Mike Fienen,Brioch Hemmings",
-      author_email='jtwhite1000@gmail.com,mnfienen@usgs.gov,b.hemmings@gns.cri.nz',
-      url='https://github.com/pypest/pyemu',
-      download_url = 'https://github.com/jtwhite79/pyemu/tarball/1.2.0',
-      license='New BSD',
-      platforms='Windows, Mac OS-X, Linux',
-      packages = ["pyemu","pyemu.pst","pyemu.plot","pyemu.utils","pyemu.mat","pyemu.prototypes"],
-      version="1.2.0")
+import versioneer  # noqa: E402
+
+# see pyproject.toml for static project metadata
+setup(
+    version=versioneer.get_version(),
+    cmdclass=versioneer.get_cmdclass(),
+)


### PR DESCRIPTION
This PR does a few things:
- Complete versioneer setup, ignore from autoapi docs
- Move project metadata from setup.py to [pyproject.toml](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html)
- Set minimum Python 3.7, use "BSD 3-Clause" [SPDX License identifier](https://spdx.org/licenses/) ("New BSD" isn't on the list)
- Add dependencies and optional-dependencies sections
- Add multiple project URLs (shown in PyPI)
- Add .readthedocs.yml which specifies extra_requirements
- Remove requirements files, which are no longer needed

You can see the version is not hard-coded anywhere, but determined from the tags:
```bash
$ python -c "import pyemu; print(pyemu.__version__)"
1.2.0+110.g090e5d78
$ python setup.py --version
1.2.0+110.g090e5d78
```
Also, the correct way to build python packages is to use [build](https://github.com/pypa/build):
```bash
$ pip install build
$ python -m build
```
which will create a `.tar.gz` sdist and `.whl` wheel file to upload via twine.