### PR TITLE
Fix issue with n headerlines > n rows in list-like par files

### DIFF
--- a/autotest/pst_from_tests.py
+++ b/autotest/pst_from_tests.py
@@ -122,9 +122,9 @@ def freyberg_test():
                       "Processed into tabular form using the lines:\n",
                       "sfo = flopy.utils.SfrFile('freyberg.sfr.out')\n",
                       "sfo.get_dataframe().to_csv('freyberg.sfo.dat')\n"])
-        sfodf.sort_index(axis=1).to_csv(fp, sep=' ', index_label='idx',line_terminator='\n')
+        sfodf.sort_index(axis=1).to_csv(fp, sep=' ', index_label='idx', lineterminator='\n')
     sfodf.sort_index(axis=1).to_csv(os.path.join(m.model_ws, 'freyberg.sfo.csv'),
-                 index_label='idx',line_terminator='\n')
+                 index_label='idx',lineterminator='\n')
     template_ws = "new_temp"
     if os.path.exists(template_ws):
         shutil.rmtree(template_ws)
@@ -189,7 +189,7 @@ def freyberg_test():
          "'Processed into tabular form using the lines:\\n', "
          "'sfo = flopy.utils.SfrFile(`freyberg.sfr.out`)\\n', "
          "'sfo.get_dataframe().to_csv(`freyberg.sfo.dat`)\\n'])",
-         "    sfodf.sort_index(axis=1).to_csv(fp, sep=' ', index_label='idx',line_terminator='\\n')"])
+         "    sfodf.sort_index(axis=1).to_csv(fp, sep=' ', index_label='idx',lineterminator='\\n')"])
     # csv version of sfr obs
     # sfr outputs to obs
     pf.add_observations('freyberg.sfo.csv', insfile=None,
@@ -692,6 +692,21 @@ def mf6_freyberg_test():
     rch_temporal_gs = pyemu.geostats.GeoStruct(variograms=pyemu.geostats.ExpVario(contribution=1.0,a=60))
     pf.extra_py_imports.append('flopy')
     ib = m.dis.idomain[0].array
+    with open(os.path.join(template_ws, "inflow1.txt"), 'w') as fp:
+        fp.write("# rid type rate idx0 idx1\n")
+        fp.write("205 666 500000.0 1 1")
+    pf.add_parameters(filenames='inflow1.txt',
+                      pargp='inflow1',
+                      comment_char='#',
+                      use_cols=2,
+                      index_cols=0,
+                      upper_bound=10,
+                      lower_bound=0.1,
+                      par_type="grid",
+                      # mfile_skip=1
+                      )
+
+
     ft, ftd = _gen_dummy_obs_file(pf.new_d, sep=',', ext='txt')
     pf.add_parameters(filenames=f, par_type="grid", mfile_skip=1, index_cols=0,
                       use_cols=[2], par_name_base="tmp",
@@ -3844,14 +3859,14 @@ if __name__ == "__main__":
     # invest()
     # freyberg_test()
     #freyberg_prior_build_test()
-    # mf6_freyberg_test()
+    mf6_freyberg_test()
     #$mf6_freyberg_da_test()
     #shortname_conversion_test()
     #mf6_freyberg_shortnames_test()
     #mf6_freyberg_direct_test()
     #mf6_freyberg_varying_idomain()
     # xsec_test()
-    mf6_freyberg_short_direct_test()
+    # mf6_freyberg_short_direct_test()
     # mf6_add_various_obs_test()
     # mf6_subdir_test()
     # tpf = TestPstFrom()

--- a/pyemu/pst/pst_utils.py
+++ b/pyemu/pst/pst_utils.py
@@ -653,11 +653,20 @@ def _populate_dataframe(index, columns, default_dict, dtype):
         This function is called as part of constructing a generic Pst instance
 
     """
-    new_df = pd.DataFrame(index=index, columns=columns)
-    for fieldname, dt in zip(columns, dtype.descr):
-        default = default_dict[fieldname]
-        new_df.loc[:, fieldname] = default
-        new_df.loc[:, fieldname] = new_df.loc[:, fieldname].astype(dt[1])
+    new_df = pd.concat(
+        [pd.Series(default_dict[fieldname],
+                   index=index,
+                   name=fieldname).astype(dt[1])
+         for fieldname, dt in zip(columns, dtype.descr)],
+        axis=1
+    )
+    # new_df = pd.DataFrame(index=index)
+    # for fieldname, dt in zip(columns, dtype.descr):
+    #     default = default_dict[fieldname]
+    #     new_df[fieldname] = pd.Series(default,
+    #                                   index=new_df.index,
+    #                                   name=fieldname).astype(dt[1])
+        # new_df.loc[:, fieldname] = new_df.loc[:, fieldname].astype(dt[1])
     return new_df
 
 

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -4394,7 +4394,7 @@ def _process_list_file(model_file, df):
     with open(model_file, "w") as fo:
         kwargs = {}
         if "win" in platform.platform().lower():
-            kwargs = {"line_terminator": "\n"}
+            kwargs = {"lineterminator": "\n"}
         if len(storehead) != 0:
             fo.write("\n".join(storehead))
             fo.flush()
@@ -4691,9 +4691,9 @@ def build_jac_test_csv(pst, num_steps, par_names=None, forward=True):
 
 def _write_df_tpl(filename, df, sep=",", tpl_marker="~", headerlines=None, **kwargs):
     """function write a pandas dataframe to a template file."""
-    if "line_terminator" not in kwargs:
+    if "lineterminator" not in kwargs:
         if "win" in platform.platform().lower():
-            kwargs["line_terminator"] = "\n"
+            kwargs["lineterminator"] = "\n"
     with open(filename, "w") as f:
         f.write("ptf {0}\n".format(tpl_marker))
         f.flush()

--- a/pyemu/utils/pp_utils.py
+++ b/pyemu/utils/pp_utils.py
@@ -250,8 +250,8 @@ def setup_pilotpoints_grid(
                         tpl_files.append(tpl_filename)
 
     par_info = pd.concat(par_info)
-    for field in ["k", "i", "j"]:
-        par_info.loc[:, field] = par_info.loc[:, field].apply(np.int64)
+    fields = ["k", "i", "j"]
+    par_info.loc[:, fields] = par_info.loc[:, fields].astype(int)
     for key, default in pst_config["par_defaults"].items():
         if key in par_info.columns:
             continue

--- a/pyemu/utils/pst_from.py
+++ b/pyemu/utils/pst_from.py
@@ -975,7 +975,7 @@ class PstFrom(object):
                 if len(storehead) != 0:
                     kwargs = {}
                     if "win" in platform.platform().lower():
-                        kwargs = {"line_terminator": "\n"}
+                        kwargs = {"lineterminator": "\n"}
                     with open(org_file, "w") as fp:
                         lc = 0
                         fr = 0
@@ -1001,15 +1001,15 @@ class PstFrom(object):
                             fp.write(storehead[key])
                             fp.flush()
                             lc += 1
-                        if lc < len(df):
-                            df.iloc[fr:].to_csv(
-                                fp,
-                                sep=",",
-                                mode="a",
-                                header=hheader,
-                                index=False,
-                                **kwargs,
-                            )
+                        # if lc < len(df):  # finish off remaining table (todo: when supporting mid-table comments...)
+                        df.iloc[fr:].to_csv(
+                            fp,
+                            sep=",",
+                            mode="a",
+                            header=hheader,
+                            index=False,
+                            **kwargs,
+                        )
                 else:
                     df.to_csv(
                         org_file,


### PR DESCRIPTION
Legacy from early attempts to support mid-file comment lines in list-like par files meant that when the number of data rows in the par file was less than (or equal to) the number of header/skipped/commented lines the file data was not being written to org/

Should fix #371

+ trying to catch a few line_terminator -> lineterminator deprecations
+ some pandas assignment changes