### PR TITLE
Hotfix strdefault

### DIFF
--- a/autotest/mat_tests.py
+++ b/autotest/mat_tests.py
@@ -693,6 +693,35 @@ def from_uncfile_firstlast_test(setup_empty_mat_temp):
         raise Exception("should have failed")
 
 
+def trunc_names_test():
+    import pyemu
+    import pandas as pd
+
+    a=pd.DataFrame({'a': [1,2,3], 'b': [4,5,6]})
+    names = ['They','We','Reality']
+    a['names'] =  names
+    a.set_index('names',inplace=True, drop=True)
+    am = pyemu.Matrix.from_dataframe(a)
+    am.to_binary('a.binary.jcb')
+    am.to_coo('a.coo.jcb')
+    # both read fine
+    ar = pyemu.Matrix.from_binary('a.coo.jcb')
+    ar = pyemu.Matrix.from_binary('a.binary.jcb')
+
+    # use longer names
+    names = ["They've done studies, you know. 60 percent of the time, it works every time.",
+             "We’ll never survive! You’re only saying that because no one ever has.",
+             "Reality is frequently inaccurate."]
+    a['names'] =  [n.replace(" ","-",) for n in names]
+    a.set_index('names',inplace=True, drop=True)
+    am = pyemu.Matrix.from_dataframe(a)
+    am.to_binary('a.binary.jcb')
+    am.to_coo('a.coo.jcb')
+
+    ar = pyemu.Matrix.from_binary('a.coo.jcb')
+    # long names save with .to_binary() can't be read with .from_binary()
+    ar = pyemu.Matrix.from_binary('a.binary.jcb')
+
 if __name__ == "__main__":
     #df_tests()
     # cov_scale_offset_test()
@@ -719,4 +748,5 @@ if __name__ == "__main__":
     # sparse_get_sparse_test()
     #dense_mat_format_test()
     #icode_minus_one_test()
-    from_uncfile_firstlast_test()
+    #from_uncfile_firstlast_test()
+    trunc_names_test()

--- a/autotest/utils_tests.py
+++ b/autotest/utils_tests.py
@@ -844,8 +844,17 @@ def geostat_draws_test(tmp_path):
     df = pyemu.pp_utils.pp_tpl_to_dataframe(tpl_file)
     df.loc[:,"zone"] = np.arange(df.shape[0])
     gs = pyemu.geostats.read_struct_file(str_file)
+    np.random.seed(pyemu.en.SEED)
     pe = pyemu.helpers.geostatistical_draws(pst_file,{gs:df},
                                           sigma_range=4)
+    np.random.seed(pyemu.en.SEED)
+    pe2 = pyemu.helpers.geostatistical_draws(pst_file,{gs:df},
+                                          sigma_range=4)
+
+    diff = pe - pe2
+    print(diff.max())
+    assert diff.max().max() == 0.0
+
 
     ttpl_file = os.path.join(tmp_path, "temp.dat.tpl")
     with open(ttpl_file, 'w') as f:
@@ -2311,7 +2320,14 @@ def ac_draw_test(tmp_path):
     pst.write(os.path.join(tmp_path, "test.pst"))
     print(pst.observation_data.distance)
 
+    np.random.seed(pyemu.en.SEED)
     oe = pyemu.helpers.autocorrelated_draw(pst, struct_dict, num_reals=100, enforce_bounds=True)
+    np.random.seed(pyemu.en.SEED)
+    oe2 = pyemu.helpers.autocorrelated_draw(pst, struct_dict, num_reals=100, enforce_bounds=True)
+    diff = oe - oe2
+    print(diff.max())
+    assert diff.max().max() == 0.0
+    
     obs = pst.observation_data
     assert oe.max().max() <= obs.upper_bound.min()
     assert oe.min().min() >= obs.lower_bound.max()
@@ -2384,8 +2400,8 @@ def test_fake_frun(freybergmf6_2_pstfrom):
 
 
 if __name__ == "__main__":
-
-    # ac_draw_test("temp")
+    #geostat_draws_test("temp")
+    ac_draw_test("temp")
     # maha_pdc_test()
     # rmr_parse_test()
     # temporal_draw_invest()
@@ -2455,11 +2471,11 @@ if __name__ == "__main__":
     # add_pi_obj_func_test()
     # ok_test()
     # ok_grid_test()
-    ok_grid_zone_test()
+    #ok_grid_zone_test()
     # ppk2fac_verf_test()
     # ok_grid_invest()
     # ok_grid_test()
     # ok_grid_zone_test()
-    maha_pdc_summary_test("temp")
+    #maha_pdc_summary_test("temp")
     # gsf_reader_test()
     # kl_test()

--- a/pyemu/mat/mat_handler.py
+++ b/pyemu/mat/mat_handler.py
@@ -2072,7 +2072,7 @@ class Matrix(object):
                         name, self.par_length
                     )
                 )
-                name = name[: self.par_length - 1]
+                name = name[: self.par_length]
             elif len(name) < self.par_length:
                 for i in range(len(name), self.par_length):
                     name = name + " "
@@ -2084,7 +2084,7 @@ class Matrix(object):
                         name, self.obs_length
                     )
                 )
-                name = name[: self.obs_length - 1]
+                name = name[: self.obs_length]
             elif len(name) < self.obs_length:
                 for i in range(len(name), self.obs_length):
                     name = name + " "

--- a/pyemu/pst/pst_handler.py
+++ b/pyemu/pst/pst_handler.py
@@ -898,7 +898,7 @@ class Pst(object):
                 df.loc[:, col] = df.loc[:, col].fillna(defaults[col])
             if col in converters:
 
-                df.loc[:, col] = df.loc[:, col].apply(converters[col])
+                df.loc[:, col] = df.loc[:, col].apply(str).apply(converters[col])
 
         return df
 

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -160,7 +160,11 @@ def autocorrelated_draw(pst,struct_dict,time_distance_col="distance",num_reals=1
     if verbose:
         print("-->draw full obs en from diagonal cov")
     full_oe = pyemu.ObservationEnsemble.from_gaussian_draw(pst,fcov,num_reals=num_reals,fill=True)
-    for gs,onames in struct_dict.items():
+    keys = list(struct_dict.keys())
+    keys.sort()
+    #for gs,onames in struct_dict.items():
+    for gs in keys:
+        onames = struct_dict[gs]
         if verbose:
             print("-->processing cov matrix for {0} items with gs {1}".format(len(onames),gs))
         dvals = obs.loc[onames,time_distance_col].values
@@ -286,14 +290,12 @@ def geostatistical_draws(
         subset=subset
     )
     full_cov_dict = {n: float(v) for n, v in zip(full_cov.col_names, full_cov.x)}
-
     # par_org = pst.parameter_data.copy  # not sure about the need or function of this line? (BH)
     par = pst.parameter_data
     par_ens = []
     pars_in_cov = set()
     keys = list(struct_dict.keys())
     keys.sort()
-
     for gs in keys:
         items = struct_dict[gs]
         if verbose:
@@ -393,6 +395,7 @@ def geostatistical_draws(
         print("adding remaining parameters to diagonal")
     fset = set(full_cov.row_names)
     diff = list(fset.difference(pars_in_cov))
+    diff.sort()
     if len(diff) > 0:
         name_dict = {name: i for i, name in enumerate(full_cov.row_names)}
         vec = np.atleast_2d(np.array([full_cov.x[name_dict[d]] for d in diff]))


### PR DESCRIPTION
fix for `Pst.load()` for the the edge case where all par or obs names can be cast to integers by pandas - this was tripping up the attempt to control the column formats/types