### PR TITLE
trying to catch up with more pandas deprecation warnings 

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ message: If you use this software, please cite both the article from preferred-c
 type: software
 title: pyEMU
 version: 1.3.3
-date-released: '2023-02-17'
+date-released: '2023-09-08'
 abstract: A python package for interfacing with PEST and PEST++, and providing model-independent data-worth, and linear and non-linear uncertainty analyses.
 repository-artifact: https://pypi.org/project/pyemu
 repository-code: https://github.com/pypest/pyemu

--- a/autotest/pst_from_tests.py
+++ b/autotest/pst_from_tests.py
@@ -3675,7 +3675,7 @@ def mf6_freyberg_arr_obs_and_headerless_test(tmp_path):
 
             pval = fobs.loc[fobs.apply(lambda x: x.i==3 and x.j==1,axis=1),"obsval"]
             assert len(pval) == 1
-            pval = pval[0]
+            pval = pval.iloc[0]
             aval = arr[3,1]
             print(fname,pval,aval)
             assert pval == aval,"{0},{1},{2}".format(fname,pval,aval)

--- a/autotest/pst_tests.py
+++ b/autotest/pst_tests.py
@@ -241,8 +241,7 @@ def tied_test(tmp_path):
     par = pst.parameter_data
     par.loc[pst.par_names[2], "partrans"] = "tied"
     print(pst.tied)
-    par.loc[pst.par_names[2], "partied"] = pd.Series("junk1",
-                                                     index=pst.par_names[2])
+    par.loc[pst.par_names[2], "partied"] = "junk1"
     try:
         pst.write(os.path.join(tmp_path, "test.pst"))
     except:
@@ -254,8 +253,10 @@ def tied_test(tmp_path):
     pst = pyemu.Pst(os.path.join("pst", "pest.pst"))
     print(pst.tied)
     par = pst.parameter_data
-    par.loc[pst.par_names[2], "partrans"] = "tied"
-    par.loc[pst.par_names[2], "partied"] = "junk"
+    idx = pst.par_names[2]
+    par.loc[idx, "partrans"] = "tied"
+    par["partied"] = pd.Series(np.nan, index=par.index, dtype=object)
+    par.loc[idx, "partied"] = "junk"
     try:
 
         pst.write(os.path.join(tmp_path, "test.pst"))
@@ -382,7 +383,7 @@ def add_pi_test(tmp_path):
     pst = pyemu.Pst(os.path.join("pst", "pest.pst"))
     pst.prior_information = pst.null_prior
     par_names = pst.parameter_data.parnme[:10]
-    pst.add_pi_equation(par_names, coef_dict={par_names[1]: -1.0})
+    pst.add_pi_equation(par_names, coef_dict={par_names.iloc[1]: -1.0})
     pst.write(os.path.join(tmp_path, "test.pst"))
 
     pst = pyemu.Pst(os.path.join(tmp_path, "test.pst"))
@@ -404,13 +405,15 @@ def setattr_test(tmp_path):
 def add_pars_test(tmp_path):
     import os
     import pyemu
+    import pandas as pd
     pst = pyemu.Pst(os.path.join("pst", "pest.pst"))
     npar = pst.npar
     tpl_file = os.path.join(tmp_path, "crap.in.tpl")
+    idx = pst.parameter_data.parnme.iloc[0]
     with open(tpl_file, 'w') as f:
         f.write("ptf ~\n")
         f.write("  ~junk1   ~\n")
-        f.write("  ~ {0}  ~\n".format(pst.parameter_data.parnme[0]))
+        f.write("  ~ {0}  ~\n".format(idx))
     print(pst.npar)
     pst.add_parameters(tpl_file, "crap.in", pst_path=tmp_path)
     assert npar + 1 == pst.npar
@@ -420,8 +423,14 @@ def add_pars_test(tmp_path):
 
     pyemu.helpers.zero_order_tikhonov(pst)
     nprior,npar = pst.nprior,pst.npar
-    pst.parameter_data.loc[pst.par_names[0], "partrans"] = "tied"
-    pst.parameter_data.loc[pst.par_names[0], "partied"] = "junk1"
+    idx = pst.par_names[0]
+    pst.parameter_data.loc[idx, "partrans"] = "tied"
+    # urgh pandas is getting grumpy trying to set string to
+    # an absent columns
+    pst.parameter_data["partied"] = pd.Series(
+        np.nan, index=pst.parameter_data.index, dtype=object
+    )
+    pst.parameter_data.loc[idx, "partied"] = 'junk1'
     try:
         pst.drop_parameters(tpl_file,tmp_path)
     except:
@@ -577,10 +586,11 @@ def rectify_pgroup_test(tmp_path):
     pst = pyemu.Pst(os.path.join("pst", "pest.pst"))
     npar = pst.npar
     tpl_file = os.path.join(tmp_path, "crap.in.tpl")
+    idx = pst.parameter_data.parnme.iloc[0]
     with open(tpl_file, 'w') as f:
         f.write("ptf ~\n")
         f.write("  ~junk1   ~\n")
-        f.write("  ~ {0}  ~\n".format(pst.parameter_data.parnme[0]))
+        f.write("  ~ {0}  ~\n".format(idx))
     # print(pst.parameter_groups)
 
     pst.add_parameters(tpl_file, "crap.in", pst_path=tmp_path)
@@ -1145,7 +1155,8 @@ def write2_nan_test(tmp_path):
     os.chdir(bd)
 
     pst = pyemu.Pst(os.path.join("pst", "pest.pst"))
-    pst.parameter_groups.loc[pst.parameter_groups.pargpnme[0], "derinc"] = np.NaN
+    idx = pst.parameter_groups.pargpnme.iloc[0]
+    pst.parameter_groups.loc[idx, "derinc"] = np.NaN
     os.chdir(tmp_path)
     try:
         _try_write2fail(pst, newpst_f, order=[2, 1])

--- a/autotest/pst_tests.py
+++ b/autotest/pst_tests.py
@@ -218,6 +218,7 @@ def comments_test(tmp_path):
 def tied_test(tmp_path):
     import os
     import pyemu
+    import pandas as pd
     pst_dir = os.path.join("pst")
     pst = pyemu.Pst(os.path.join(pst_dir, "br_opt_no_zero_weighted.pst"))
     print(pst.tied)
@@ -240,7 +241,8 @@ def tied_test(tmp_path):
     par = pst.parameter_data
     par.loc[pst.par_names[2], "partrans"] = "tied"
     print(pst.tied)
-    par.loc[pst.par_names[2], "partied"] = "junk1"
+    par.loc[pst.par_names[2], "partied"] = pd.Series("junk1",
+                                                     index=pst.par_names[2])
     try:
         pst.write(os.path.join(tmp_path, "test.pst"))
     except:
@@ -1324,7 +1326,7 @@ def parrep_test(tmp_path):
         pyemu.ParameterEnsemble(pst=pst,df=parens).to_binary('fake_parens.jcb')
         # test the parfile style
         pst.parrep('fake.par')
-        assert pst.parameter_data.parval1[0] == pst.parameter_data.parlbnd[0]
+        assert pst.parameter_data.parval1.iloc[0] == pst.parameter_data.parlbnd.iloc[0]
         assert np.allclose(pst.parameter_data.iloc[1:].parval1.values,parvals[1:],atol=0.0001)
         assert pst.control_data.noptmax == 0
         pst.parrep('fake.par', noptmax=99, enforce_bounds=False)
@@ -1333,7 +1335,7 @@ def parrep_test(tmp_path):
 
         # now test the ensemble style
         pst.parrep('fake.par.0.csv')
-        assert pst.parameter_data.parval1[0] == pst.parameter_data.parlbnd[0]
+        assert pst.parameter_data.parval1.iloc[0] == pst.parameter_data.parlbnd.iloc[0]
         assert np.allclose(pst.parameter_data.iloc[1:].parval1.values,parvals[1:],atol=0.0001)
 
         pst.parrep('fake.par.0.nobase.csv')

--- a/autotest/utils_tests.py
+++ b/autotest/utils_tests.py
@@ -591,7 +591,7 @@ def ok_grid_test(tmp_path):
     pts_data = pd.DataFrame({"x":ptx,"y":pty,"name":ptname})
     pts_data.index = pts_data.name
     pts_data = pts_data.loc[:,["x","y","name"]]
-
+    pts_data['name'] = pts_data.name.astype(str)
 
     sr = pyemu.helpers.SpatialReference(delr=delr,delc=delc)
     pts_data.loc["i0j0", :] = [sr.xcentergrid[0,0],sr.ycentergrid[0,0],"i0j0"]
@@ -624,13 +624,13 @@ def ok_grid_zone_test(tmp_path):
     pts_data = pd.DataFrame({"x":ptx,"y":pty,"name":ptname})
     pts_data.index = pts_data.name
     pts_data = pts_data.loc[:,["x","y","name"]]
-
+    pts_data['name'] = pts_data.name.astype(str)
 
     sr = pyemu.helpers.SpatialReference(delr=delr,delc=delc)
     pts_data.loc["i0j0", :] = [sr.xcentergrid[0,0],sr.ycentergrid[0,0],"i0j0"]
     pts_data.loc["imxjmx", :] = [sr.xcentergrid[-1, -1], sr.ycentergrid[-1, -1], "imxjmx"]
-    pts_data.loc[:,"zone"] = 1
-    pts_data.zone.iloc[1] = 2
+    pts_data.loc[:, "zone"] = 1
+    pts_data.loc[pts_data.index[1], "zone"] = 2
     print(pts_data.zone.unique())
     str_file = os.path.join("utils","struct_test.dat")
     gs = pyemu.utils.geostats.read_struct_file(str_file)[0]
@@ -780,6 +780,7 @@ def geostat_prior_builder_test(tmp_path):
     import os
     import numpy as np
     import pyemu
+    import pandas as pd
     pst_file = os.path.join("pst","pest.pst")
     pst = pyemu.Pst(pst_file)
     # print(pst.parameter_data)
@@ -804,6 +805,9 @@ def geostat_prior_builder_test(tmp_path):
     assert np.array_equiv(d1, d2)
 
     pst.parameter_data.loc[pst.par_names[1:10], "partrans"] = "tied"
+    pst.parameter_data['partied'] = pd.Series(
+        np.nan, index=pst.parameter_data.index, dtype=object
+    )
     pst.parameter_data.loc[pst.par_names[1:10], "partied"] = pst.par_names[0]
     cov = pyemu.helpers.geostatistical_prior_builder(pst, {gs: df},
                                                      sigma_range=4)
@@ -841,6 +845,9 @@ def geostat_draws_test(tmp_path):
     pe = pyemu.helpers.geostatistical_draws(pst_file,{str_file:tpl_file,str_file:df_one})
     assert (pe.shape == pe.dropna().shape)
 
+    pst.parameter_data["partied"] = pd.Series(
+        np.nan, index=pst.parameter_data.index, dtype=object
+    )
     pst.parameter_data.loc[pst.par_names[1:10], "partrans"] = "tied"
     pst.parameter_data.loc[pst.par_names[1:10], "partied"] = pst.par_names[0]
     pe = pyemu.helpers.geostatistical_draws(pst, {str_file: tpl_file})
@@ -2277,7 +2284,6 @@ def rmr_parse_test():
     df = pyemu.helpers.parse_rmr_file(os.path.join("utils","pest_local_pdc.rmr"))
 
 
-@pytest.mark.order(0)
 def ac_draw_test(tmp_path):
     import pyemu
     import numpy as np

--- a/autotest/utils_tests.py
+++ b/autotest/utils_tests.py
@@ -2354,10 +2354,11 @@ def ac_draw_test(tmp_path):
     oe = pyemu.helpers.autocorrelated_draw(pst,struct_dict,num_reals=8000)
 
     obs = pst.observation_data
-    obs.loc[:,"emp_std"] = oe.std().loc[obs.obsnme]
-    obs.loc[:,"std_diff"] = 100 * np.abs(obs.emp_std-obs.standard_deviation)/obs.emp_std
-    print(obs.std_diff.min(),obs.std_diff.max())
-    assert obs.std_diff.max() < 5.0
+    obs["emp_std"] = oe.std().loc[obs.obsnme]
+    obs["std_diff"] = 100 * np.abs(obs.emp_std-obs.standard_deviation)/obs.emp_std
+    sel = obs.emp_std != 0
+    print(obs[sel].std_diff.min(), obs[sel].std_diff.max())
+    assert obs[sel].std_diff.max() < 5.0
 
 
     # pst.observation_data.loc[:,"upper_bound"] = np.nan

--- a/pyemu/en.py
+++ b/pyemu/en.py
@@ -84,7 +84,9 @@ class Ensemble(object):
     """
 
     def __init__(self, pst, df, istransformed=False):
-        self._df = df.replace([np.inf, -np.inf], np.nan)
+        self._df = df
+        if df is not None:
+            self._df = self._df.replace([np.inf, -np.inf], np.nan)
         """`pandas.DataFrame`: the underlying dataframe that stores the realized values"""
         self.pst = pst
         """`pyemu.Pst`: control file instance"""

--- a/pyemu/en.py
+++ b/pyemu/en.py
@@ -84,7 +84,7 @@ class Ensemble(object):
     """
 
     def __init__(self, pst, df, istransformed=False):
-        self._df = df
+        self._df = df.replace([np.inf, -np.inf], np.nan)
         """`pandas.DataFrame`: the underlying dataframe that stores the realized values"""
         self.pst = pst
         """`pyemu.Pst`: control file instance"""

--- a/pyemu/utils/gw_utils.py
+++ b/pyemu/utils/gw_utils.py
@@ -1506,8 +1506,8 @@ def setup_sfr_seg_parameters(
         # look across all kper in multiindex df to check for values entry - fill with absmax should capture entries
         else:
             seg_data.loc[:, par_col] = (
-                seg_data_all_kper.loc[:, (slice(None), par_col)]
-                    .abs().groupby(level=1, axis=1).max()
+                seg_data_all_kper.loc[:, (slice(None), par_col)].abs(
+                ).T.groupby(level=1).max().T
             )
     if len(missing) > 0:
         warnings.warn(
@@ -1569,11 +1569,12 @@ def setup_sfr_seg_parameters(
             tpl_str.extend(list(pnames.values))
         if par_col in tmp_par_cols.keys():
             parnme = tmp_df.index.map(
-                lambda x: "{0}_{1:04d}_tmp".format(par_col, int(x))
+                lambda x: f"{par_col}_{int(x):04d}_tmp"
                 if x in tmp_par_cols[par_col]
                 else 1.0
             )
             sel = parnme != 1.0
+            tmp_df[par_col] = tmp_df[par_col].astype(object)
             tmp_df.loc[sel, par_col] = parnme[sel].map(lambda x: "~   {0}  ~".format(x))
             tmp_tpl_str.extend(list(tmp_df.loc[sel, par_col].values))
             tmp_pnames.extend(list(parnme[sel].values))

--- a/pyemu/utils/smp_utils.py
+++ b/pyemu/utils/smp_utils.py
@@ -198,11 +198,10 @@ def smp_to_dataframe(smp_filename, datetime_format=None):
     df = pd.read_csv(
         smp_filename,
         delim_whitespace=True,
-        parse_dates={"datetime": ["date", "time"]},
         header=None,
         names=["name", "date", "time", "value"],
         dtype={"name": object, "value": np.float64},
         na_values=["dry"],
-        date_parser=date_func,
     )
+    df['datetime'] = (df.date + " " + df.time).apply(date_func)
     return df


### PR DESCRIPTION
Hopefully addresses some of what is in #461.

Recommend we keep pandas pinned to <2.1 for now, mostly due to:
https://github.com/pandas-dev/pandas/issues/54918 -- we could have commas in space delimited input/output files
https://github.com/pandas-dev/pandas/issues/55025 -- I don't want to have to add lines to check if column exists and it the right type before assigning values (that could be string or float, [or other type]).