### PR TITLE
A couple little things

### DIFF
--- a/autotest/pst_from_tests.py
+++ b/autotest/pst_from_tests.py
@@ -1160,7 +1160,14 @@ def mf6_freyberg_test(tmp_path):
         assert rcov.sum().sum() > dsum
 
         num_reals = 100
-        pe = pf.draw(num_reals, use_specsim=True)
+        pe = pf.draw(num_reals, use_specsim=False)
+        #pe = pe.copy()
+        pe.enforce()
+        lbnd = pst.parameter_data.parlbnd.to_dict()
+        for pname,lb in lbnd.items():
+            diff = pe.loc[:,pname].values - lb
+            print(pname,lb,diff.min())
+            assert diff.min() >= 0
         pe.to_binary(Path(template_ws, "prior.jcb"))
         assert pe.shape[1] == pst.npar_adj, "{0} vs {1}".format(pe.shape[1], pst.npar_adj)
         assert pe.shape[0] == num_reals
@@ -5159,7 +5166,7 @@ if __name__ == "__main__":
     # invest()
     #freyberg_test(os.path.abspath("."))
     # freyberg_prior_build_test()
-    # mf6_freyberg_test()
+    mf6_freyberg_test(os.path.abspath("."))
     #$mf6_freyberg_da_test()
     #shortname_conversion_test()
     #mf6_freyberg_shortnames_test()
@@ -5181,7 +5188,7 @@ if __name__ == "__main__":
     # tpf.test_add_list_parameters()
     # # pstfrom_profile()
     # mf6_freyberg_arr_obs_and_headerless_test()
-    usg_freyberg_test(".")
+    #usg_freyberg_test(".")
     #vertex_grid_test()
     #direct_quickfull_test()
     #list_float_int_index_test()

--- a/pyemu/utils/os_utils.py
+++ b/pyemu/utils/os_utils.py
@@ -126,9 +126,9 @@ def run(cmd_str, cwd=".", verbose=False):
             raise Exception("run() returned non-zero: {0}".format(ret_val))
     else:
         estat = os.WEXITSTATUS(ret_val)
-        if estat != 0:
-            raise Exception("run() returned non-zero: {0}".format(estat))
-
+        if estat != 0 or ret_val != 0:
+            raise Exception("run() returned non-zero: {0},{1}".format(estat,ret_val))
+        
 
 def _try_remove_existing(d, forgive=False):
     try:

--- a/pyemu/utils/pst_from.py
+++ b/pyemu/utils/pst_from.py
@@ -603,7 +603,7 @@ class PstFrom(object):
         else:
             pe = pyemu.ParameterEnsemble(pst=self.pst, df=gr_par_pe)
         self.logger.log("drawing realizations")
-        return pe
+        return pe.copy()
 
     def build_pst(self, filename=None, update=False, version=1):
         """Build control file from i/o files in PstFrom object.


### PR DESCRIPTION
Fixed the run util to make sure we catch non-zero return codes on *nix systems.  Also ran into some strangeness the geostat draw helper and the enforcing bounds.  Seemed like it was a pandas memory/pointer thing but I didnt have interest in sorting it out.  @briochh can you live with returning a copy of `pe`?