### PR TITLE
hot fix for pandas replace issue

### DIFF
--- a/pyemu/utils/pst_from.py
+++ b/pyemu/utils/pst_from.py
@@ -435,9 +435,9 @@ class PstFrom(object):
             for k, li in gps.items():
                 tdf = []
                 for df in li:
-                    tdf.append(
-                        df.replace({'parnme': mapdict}).rename(index=mapdict)
-                    )
+                    df['parnme'] = df.parnme.apply(lambda x: mapdict.get(x, x))
+                    df = df.set_index('parnme', drop=False)
+                    tdf.append(df)
                 df_dict[k] = tdf
             self.par_struct_dict[gs] = df_dict
 


### PR DESCRIPTION
pandas replace in short names conversion of par_struct_dicts was hanging indefinitely (or just incredibly slow) after version 2.2. Falling back to good old apply with dictionary look up.