### PR TITLE
Hotfix: underscore in add_pars index_col values

### DIFF
--- a/autotest/pst_from_tests.py
+++ b/autotest/pst_from_tests.py
@@ -917,6 +917,14 @@ def mf6_freyberg_test(setup_freyberg_mf6):
                                   pargp=arr_file.split('.')[1] + "_cn", zone_array=ib,
                                   upper_bound=ub, lower_bound=lb,geostruct=gr_gs)
 
+    # arr = np.loadtxt(Path(template_ws, 'freyberg6.npf_k_layer1.txt'))
+    # onecolf = Path(template_ws, '1col.txt')
+    # np.savetxt(onecolf, arr.ravel()[:,None])
+    # pdf = pf.add_parameters(filenames=onecolf.relative_to(template_ws),
+    #                   par_type="grid", par_name_base="onecol-gr",
+    #                   pargp="onecol-gr", zone_array=ib.ravel()[:,None],
+    #                   upper_bound=10, lower_bound=0.1)
+
     # add SP1 spatially constant, but temporally correlated wel flux pars
     kper = 0
     list_file = "freyberg6.wel_stress_period_data_{0}.txt".format(kper+1)

--- a/autotest/pst_from_tests.py
+++ b/autotest/pst_from_tests.py
@@ -832,10 +832,10 @@ def mf6_freyberg_test(setup_freyberg_mf6):
                       )
     with open(Path(template_ws, "inflow4.txt"), 'w') as fp:
         fp.write("# rid type rate idx0 idx1\n")
-        fp.write("204 infl 700000.3 1 1\n")
-        fp.write("205 div 1 500000.7 1\n")
-        fp.write("206 infl 800000.7 1 1\n")
-        fp.write("207 div 1 500000.7 1")
+        fp.write("204_1 infl 700000.3 1 1\n")
+        fp.write("205_1 div 1 500000.7 1\n")
+        fp.write("206_1 infl 800000.7 1 1\n")
+        fp.write("207_1 div 1 500000.7 1")
 
     inflow4_pre = pd.read_csv(Path(pf.new_d, "inflow4.txt"),
                               header=None, sep=' ', skiprows=1)
@@ -847,7 +847,7 @@ def mf6_freyberg_test(setup_freyberg_mf6):
                       upper_bound=10,
                       lower_bound=0.1,
                       par_type="grid",
-                      use_rows=[(204, "infl")],
+                      use_rows=[("204_1", "infl")],
                       )
     pf.add_parameters(filenames="inflow4.txt",
                       pargp='inflow5',

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -2091,7 +2091,7 @@ def _list_index_caster(x, add1):
     vals = []
     for xx in x:
         if xx:
-            if any(s not in " 01234456789.-" for s in xx):
+            if any(s not in " 0123456789.-" for s in xx):
                 vals.append(xx.strip().strip("'\" "))
             else:
                 if (xx.strip().isdigit() or

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -2088,9 +2088,12 @@ def _process_chunk_list_files(chunk, i, df):
 
 
 def _list_index_caster(x, add1):
-        vals = []
-        for xx in x:
-            if xx:
+    vals = []
+    for xx in x:
+        if xx:
+            if any(s not in " 01234456789.-" for s in xx):
+                vals.append(xx.strip().strip("'\" "))
+            else:
                 if (xx.strip().isdigit() or
                         (xx.strip()[0] == '-' and xx.strip()[1:].isdigit())):
                     vals.append(add1 + int(xx))
@@ -2100,7 +2103,7 @@ def _list_index_caster(x, add1):
                     except Exception as e:
                         vals.append(xx.strip().strip("'\" "))
 
-        return tuple(vals)
+    return tuple(vals)
 
 
 def _list_index_splitter_and_caster(x, add1):


### PR DESCRIPTION
Python interprets underscore (`'_'`) as a convenience notation when parsing string to float. We need to avoid this a keep strings with underscores as strings. 

Modifying interpreter to first check for non numeric + `' ', '.', '-'` in string.

Should help to address #507 #506.

Note, I would recommend trying to keep underscores out of string that eventually get passed through to obs names or par names, unless you are intending metadata propagation. The automatic metadata parsing splits on `'_'` and `':'` to fill par and obs metadata so `"this_one:0"` will be extracted to have a `one` column with a value of `'0'` for this parameter (note, the `0` is stored as a string...).