### PR TITLE
_enforce_reset() to be more explicit

### DIFF
--- a/autotest/en_tests.py
+++ b/autotest/en_tests.py
@@ -260,6 +260,7 @@ def enforce_test():
     pe.enforce(how="scale")
 
     pe = pyemu.ParameterEnsemble.from_gaussian_draw(pst, num_reals=num_reals)
+    pe._df["mult1"] = pe._df["mult1"].astype("float")
     pe._df.loc[0,:] += pst.parameter_data.parubnd
     pe.enforce()
     assert (pe._df.loc[0,:] - pst.parameter_data.parubnd).apply(np.abs).sum() == 0.0
@@ -718,7 +719,7 @@ if __name__ == "__main__":
     #deviations_test()
     # as_pyemu_matrix_test()
     # dropna_test()
-    #enforce_test()
+    enforce_test()
     #pnulpar_test()
     # triangular_draw_test()
     # uniform_draw_test()

--- a/autotest/en_tests.py
+++ b/autotest/en_tests.py
@@ -504,7 +504,7 @@ def factor_draw_test():
     d = (sd_eig - sd_svd).apply(np.abs)
     assert d.max() < 0.5,d.sort_values()
 
-    num_reals = 10
+    num_reals = 1000
     pe_eig = pyemu.ParameterEnsemble.from_gaussian_draw(pst, cov=cov, num_reals=num_reals, factor="eigen")
 
     emp_cov = pe_eig.covariance_matrix()
@@ -518,7 +518,7 @@ def emp_cov_draw_test():
 
     pst = pyemu.Pst(os.path.join("en","pest.pst"))
     cov = pyemu.Cov.from_binary(os.path.join("en","cov.jcb"))
-    num_reals = 10
+    num_reals = 1000
     pe_eig = pyemu.ParameterEnsemble.from_gaussian_draw(pst, cov=cov, num_reals=num_reals, factor="eigen")
 
     emp_cov = pe_eig.covariance_matrix()
@@ -740,10 +740,11 @@ if __name__ == "__main__":
     #fill_test()
     #factor_draw_test()
     #emp_cov_test()
-    #emp_cov_draw_test()
+    emp_cov_draw_test()
     #mixed_par_draw_2_test()
     #binary_test()
-    get_phi_vector_noise_obs_test()
-
+    #get_phi_vector_noise_obs_test()
+    #factor_draw_test()
+    #enforce_test()
 
 

--- a/autotest/en_tests.py
+++ b/autotest/en_tests.py
@@ -264,12 +264,21 @@ def enforce_test():
     pe.enforce()
     assert (pe._df.loc[0,:] - pst.parameter_data.parubnd).apply(np.abs).sum() == 0.0
 
+    # mixed numpy types test
     pe = pyemu.ParameterEnsemble.from_gaussian_draw(pst, num_reals=num_reals)
     pe._df["mult1"] = pe._df["mult1"].astype("float")
     pe._df.loc[0,:] += pst.parameter_data.parubnd
     pe.enforce()
     assert (pe._df.loc[0,:] - pst.parameter_data.parubnd).apply(np.abs).sum() == 0.0
 
+    # columns out of order test
+    pe = pyemu.ParameterEnsemble.from_gaussian_draw(pst, num_reals=num_reals)
+    pe._df.loc[0,:] += pst.parameter_data.parubnd
+    cols_arr = pe._df.columns.values
+    cols_out_of_order = np.append(cols_arr[1:], [cols_arr[0]])
+    pe._df = pe._df[cols_out_of_order]
+    pe.enforce()
+    assert (pe._df.loc[0,:] - pst.parameter_data.parubnd).apply(np.abs).sum() == 0.0
 
     pe._df.loc[0, :] += pst.parameter_data.parubnd
     pe._df.loc[1:,:] = pst.parameter_data.parval1.values

--- a/autotest/en_tests.py
+++ b/autotest/en_tests.py
@@ -260,6 +260,11 @@ def enforce_test():
     pe.enforce(how="scale")
 
     pe = pyemu.ParameterEnsemble.from_gaussian_draw(pst, num_reals=num_reals)
+    pe._df.loc[0,:] += pst.parameter_data.parubnd
+    pe.enforce()
+    assert (pe._df.loc[0,:] - pst.parameter_data.parubnd).apply(np.abs).sum() == 0.0
+
+    pe = pyemu.ParameterEnsemble.from_gaussian_draw(pst, num_reals=num_reals)
     pe._df["mult1"] = pe._df["mult1"].astype("float")
     pe._df.loc[0,:] += pst.parameter_data.parubnd
     pe.enforce()
@@ -719,7 +724,7 @@ if __name__ == "__main__":
     #deviations_test()
     # as_pyemu_matrix_test()
     # dropna_test()
-    enforce_test()
+    #enforce_test()
     #pnulpar_test()
     # triangular_draw_test()
     # uniform_draw_test()

--- a/autotest/utils_tests.py
+++ b/autotest/utils_tests.py
@@ -2485,13 +2485,13 @@ def thresh_pars_test():
     tot = inact_arr.sum()
     prop = np.nansum(tarr) / tot
     print(prop,cat_dict[1])
-    assert np.isclose(prop,cat_dict[1][0],0.01)
+    assert np.isclose(prop,cat_dict[1][0],0.01),"cat_dict 1,{0} vs {1}".format(prop,cat_dict[1])
 
     tarr = np.zeros_like(newarr)
     tarr[np.isclose(newarr, cat_dict[2][1])] = 1.0
     prop = tarr.sum() / tot
     print(prop, cat_dict[2])
-    assert np.isclose(prop, cat_dict[2][0],0.01)
+    assert np.isclose(prop, cat_dict[2][0],0.01),"cat_dict 2,{0} vs {1}".format(prop,cat_dict[2])
 
     # import matplotlib.pyplot as plt
     # fig,axes = plt.subplots(1,2,figsize=(10,5))
@@ -2508,7 +2508,7 @@ def thresh_pars_test():
 
 
 if __name__ == "__main__":
-    # thresh_pars_test()
+    thresh_pars_test()
     #obs_ensemble_quantile_test()
     #geostat_draws_test("temp")
     # ac_draw_test("temp")
@@ -2590,4 +2590,4 @@ if __name__ == "__main__":
     # ok_grid_zone_test()
     #maha_pdc_summary_test("temp")
     # gsf_reader_test()
-    kl_test()
+    #kl_test()

--- a/pyemu/en.py
+++ b/pyemu/en.py
@@ -1697,11 +1697,6 @@ class ParameterEnsemble(Ensemble):
         violating vals to bound
         """
 
-        ub = (self.ubnd * (1.0 - bound_tol)).to_dict()
-        lb = (self.lbnd * (1.0 + bound_tol)).to_dict()
-
-        val_arr = self._df.to_numpy()
-        for iname, name in enumerate(self.columns):
-            val_arr[val_arr[:, iname] > ub[name], iname] = ub[name]
-            val_arr[val_arr[:, iname] < lb[name], iname] = lb[name]
-        self._df = pd.DataFrame(val_arr, index=self._df.index, columns=self._df.columns)
+        ub = self.ubnd * (1.0 - bound_tol)
+        lb = self.lbnd * (1.0 + bound_tol)
+        self._df = self._df.clip(lb, ub, axis=1)

--- a/pyemu/en.py
+++ b/pyemu/en.py
@@ -1700,7 +1700,8 @@ class ParameterEnsemble(Ensemble):
         ub = (self.ubnd * (1.0 - bound_tol)).to_dict()
         lb = (self.lbnd * (1.0 + bound_tol)).to_dict()
 
-        val_arr = self._df.values
+        val_arr = self._df.to_numpy()
         for iname, name in enumerate(self.columns):
             val_arr[val_arr[:, iname] > ub[name], iname] = ub[name]
             val_arr[val_arr[:, iname] < lb[name], iname] = lb[name]
+        self._df = pd.DataFrame(val_arr, index=self._df.index, columns=self._df.columns)


### PR DESCRIPTION
This fixes issue #510 

Again I am not 100% why I was getting this issue for one of my models because the dtypes appeared to be fine after drawing ensembles, but it was clear pe.enforce() was not working for me (values outside both the lower and upper bounds not changing) and this fix I made by locally editing _enforce_reset() fixed it. I added a test that fails without this _enforce_reset() update but passes with it.

The vast majority of the time I think the dtypes should all be float64/upcastable to float64 and this will not be an issue. But I think it is a good idea to be more explicit in general anyways as nothing will notify you about this (pandas documentation has a warning now about using values: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.values.html and in the links in issue #510 they discuss how this in an implementation detail and they might change implementation thus the pandas team aren't changing this behaviour).