### PR TITLE
Feat normal-score-transform for DSI

### DIFF
--- a/autotest/la_tests.py
+++ b/autotest/la_tests.py
@@ -629,7 +629,7 @@ def ends_freyberg_dsi_test(tmp_path):
     #shutil.copy2(os.path.join(test_d,"pestpp-ies.exe"),os.path.join(t_d,"pestpp-ies.exe"))
 
     pst = pyemu.Pst(os.path.join(t_d,"dsi.pst"))
-    pst.control_data.noptmax = 3
+    pst.control_data.noptmax = 0
     pst.write(os.path.join(t_d,"dsi.pst"),version=2)
     #pyemu.os_utils.run("pestpp-ies dsi.pst",cwd="dsi_template")
     m_d = os.path.join(tmp_path,"master_dsi")
@@ -642,7 +642,7 @@ def ends_freyberg_dsi_test(tmp_path):
     #shutil.copy2(os.path.join(test_d,"pestpp-ies.exe"),os.path.join(t_d,"pestpp-ies.exe"))
 
     pst = pyemu.Pst(os.path.join(t_d,"dsi.pst"))
-    pst.control_data.noptmax = 3
+    pst.control_data.noptmax = 0
     pst.write(os.path.join(t_d,"dsi.pst"),version=2)
     pyemu.os_utils.start_workers(t_d,"pestpp-ies","dsi.pst",num_workers=15,worker_root=tmp_path,
                                  master_dir=m_d)
@@ -654,7 +654,7 @@ def ends_freyberg_dsi_test(tmp_path):
     #shutil.copy2(os.path.join(test_d,"pestpp-ies.exe"),os.path.join(t_d,"pestpp-ies.exe"))
     
     pst = pyemu.Pst(os.path.join(t_d,"dsi.pst"))
-    pst.control_data.noptmax = 3
+    pst.control_data.noptmax = 0
     pst.write(os.path.join(t_d,"dsi.pst"),version=2)
     pyemu.os_utils.start_workers(t_d,"pestpp-ies","dsi.pst",num_workers=15,worker_root=tmp_path,
                                  master_dir=m_d)
@@ -669,7 +669,7 @@ def ends_freyberg_dsi_test(tmp_path):
     #shutil.copy2(os.path.join(test_d,"pestpp-ies.exe"),os.path.join(t_d,"pestpp-ies.exe"))
     
     pst = pyemu.Pst(os.path.join(t_d,"dsi.pst"))
-    pst.control_data.noptmax = 3
+    pst.control_data.noptmax = 0
     pst.write(os.path.join(t_d,"dsi.pst"),version=2)
     pyemu.os_utils.start_workers(t_d,"pestpp-ies","dsi.pst",num_workers=15,worker_root=tmp_path,
                                  master_dir=m_d)

--- a/autotest/la_tests.py
+++ b/autotest/la_tests.py
@@ -645,6 +645,7 @@ def ends_freyberg_dsi_test(tmp_path):
     
     # run test with log-transform
     pst = pyemu.Pst(pst_name)
+    pst.pestpp_options["predictions"] = predictions
     pst.observation_data["obstransform"] = "log"
     ends = pyemu.EnDS(pst=pst, sim_ensemble=oe,verbose=True)
     ends.prep_for_dsi(t_d=t_d,apply_normal_score_transform=False)

--- a/autotest/la_tests.py
+++ b/autotest/la_tests.py
@@ -651,7 +651,7 @@ def ends_freyberg_dsi_test(tmp_path):
     ends.prep_for_dsi(t_d=t_d,apply_normal_score_transform=False)
     pst = pyemu.Pst(os.path.join(t_d,"dsi.pst"))
     pst.control_data.noptmax = 3
-    pst.write(os.path.join("dsi_template","dsi.pst"),version=2)
+    pst.write(os.path.join(t_d,"dsi.pst"),version=2)
     pyemu.os_utils.start_workers(t_d,"pestpp-ies","dsi.pst",num_workers=15,worker_root=tmp_path,
                                  master_dir=m_d)
 

--- a/autotest/la_tests.py
+++ b/autotest/la_tests.py
@@ -625,16 +625,14 @@ def ends_freyberg_dsi_test(tmp_path):
     ends = pyemu.EnDS(pst=pst, sim_ensemble=oe,verbose=True)
     t_d = os.path.join(tmp_path,"dsi_template")
     ends.prep_for_dsi(t_d=t_d)
-    shutil.copy(os.path.join("ends_master","pestpp-ies.exe"),
-        os.path.join(t_d,"pestpp-ies.exe"))
 
-    #pst = pyemu.Pst(os.path.join(t_d,"dsi.pst"))
-    #pst.control_data.noptmax = 3
-    #pst.write(os.path.join(t_d,"dsi.pst"),version=2)
-    ##pyemu.os_utils.run("pestpp-ies dsi.pst",cwd="dsi_template")
-    #m_d = os.path.join(tmp_path,"master_dsi")
-    #pyemu.os_utils.start_workers(t_d,"pestpp-ies","dsi.pst",num_workers=15,worker_root=tmp_path,
-    #                             master_dir=m_d)
+    pst = pyemu.Pst(os.path.join(t_d,"dsi.pst"))
+    pst.control_data.noptmax = 3
+    pst.write(os.path.join(t_d,"dsi.pst"),version=2)
+    #pyemu.os_utils.run("pestpp-ies dsi.pst",cwd="dsi_template")
+    m_d = os.path.join(tmp_path,"master_dsi")
+    pyemu.os_utils.start_workers(t_d,"pestpp-ies","dsi.pst",num_workers=15,worker_root=tmp_path,
+                                 master_dir=m_d)
 
 
     # run test wtih normal score transform
@@ -642,10 +640,9 @@ def ends_freyberg_dsi_test(tmp_path):
     pst = pyemu.Pst(os.path.join(t_d,"dsi.pst"))
     pst.control_data.noptmax = 3
     pst.write(os.path.join(t_d,"dsi.pst"),version=2)
-    shutil.copy(os.path.join('ends_master',"pestpp-ies.exe"),
-            os.path.join(t_d,"pestpp-ies.exe"))
-    pyemu.os_utils.run("pestpp-ies dsi.pst",cwd=t_d)
-
+    pyemu.os_utils.start_workers(t_d,"pestpp-ies","dsi.pst",num_workers=15,worker_root=tmp_path,
+                                 master_dir=m_d)
+    
     # run test with log-transform
     pst = pyemu.Pst(pst_name)
     pst.observation_data["obstransform"] = "log"
@@ -654,10 +651,8 @@ def ends_freyberg_dsi_test(tmp_path):
     pst = pyemu.Pst(os.path.join(t_d,"dsi.pst"))
     pst.control_data.noptmax = 3
     pst.write(os.path.join("dsi_template","dsi.pst"),version=2)
-    shutil.copy(os.path.join('ends_master',"pestpp-ies.exe"),
-                os.path.join(t_d,"pestpp-ies.exe"))
-    pyemu.os_utils.run("pestpp-ies dsi.pst",cwd=t_d)
-
+    pyemu.os_utils.start_workers(t_d,"pestpp-ies","dsi.pst",num_workers=15,worker_root=tmp_path,
+                                 master_dir=m_d)
 
 
 def plot_freyberg_dsi():

--- a/autotest/la_tests.py
+++ b/autotest/la_tests.py
@@ -620,43 +620,44 @@ def ends_freyberg_dsi_test(tmp_path):
     oe_name = pst_name.replace(".pst", ".0.obs.csv")
     oe = pyemu.ObservationEnsemble.from_csv(pst=pst, filename=oe_name).iloc[:100, :]
 
+    
+
     ends = pyemu.EnDS(pst=pst, sim_ensemble=oe,verbose=True)
     t_d = os.path.join(tmp_path,"dsi_template")
     ends.prep_for_dsi(t_d=t_d)
+    shutil.copy(os.path.join("ends_master","pestpp-ies.exe"),
+        os.path.join(t_d,"pestpp-ies.exe"))
 
-    pst = pyemu.Pst(os.path.join(t_d,"dsi.pst"))
-    pst.control_data.noptmax = 3
-    pst.write(os.path.join(t_d,"dsi.pst"),version=2)
-    #pyemu.os_utils.run("pestpp-ies dsi.pst",cwd="dsi_template")
-    m_d = os.path.join(tmp_path,"master_dsi")
-    pyemu.os_utils.start_workers(t_d,"pestpp-ies","dsi.pst",num_workers=15,worker_root=tmp_path,
-                                 master_dir=m_d)
+    #pst = pyemu.Pst(os.path.join(t_d,"dsi.pst"))
+    #pst.control_data.noptmax = 3
+    #pst.write(os.path.join(t_d,"dsi.pst"),version=2)
+    ##pyemu.os_utils.run("pestpp-ies dsi.pst",cwd="dsi_template")
+    #m_d = os.path.join(tmp_path,"master_dsi")
+    #pyemu.os_utils.start_workers(t_d,"pestpp-ies","dsi.pst",num_workers=15,worker_root=tmp_path,
+    #                             master_dir=m_d)
+
 
     # run test wtih normal score transform
     ends.prep_for_dsi(t_d=t_d,apply_normal_score_transform=True)
-
     pst = pyemu.Pst(os.path.join(t_d,"dsi.pst"))
     pst.control_data.noptmax = 3
     pst.write(os.path.join(t_d,"dsi.pst"),version=2)
-    #pyemu.os_utils.run("pestpp-ies dsi.pst",cwd="dsi_template")
-    m_d = os.path.join(tmp_path,"master_dsi")
-    pyemu.os_utils.start_workers(t_d,"pestpp-ies","dsi.pst",num_workers=15,worker_root=tmp_path,
-                                 master_dir=m_d)
+    shutil.copy(os.path.join('ends_master',"pestpp-ies.exe"),
+            os.path.join(t_d,"pestpp-ies.exe"))
+    pyemu.os_utils.run("pestpp-ies dsi.pst",cwd=t_d)
 
     # run test with log-transform
     pst = pyemu.Pst(pst_name)
     pst.observation_data["obstransform"] = "log"
     ends = pyemu.EnDS(pst=pst, sim_ensemble=oe,verbose=True)
     ends.prep_for_dsi(t_d=t_d,apply_normal_score_transform=False)
-
     pst = pyemu.Pst(os.path.join(t_d,"dsi.pst"))
     pst.control_data.noptmax = 3
-    
-    pst.write(os.path.join(t_d,"dsi.pst"),version=2)
-    #pyemu.os_utils.run("pestpp-ies dsi.pst",cwd="dsi_template")
-    m_d = os.path.join(tmp_path,"master_dsi")
-    pyemu.os_utils.start_workers(t_d,"pestpp-ies","dsi.pst",num_workers=15,worker_root=tmp_path,
-                                 master_dir=m_d)
+    pst.write(os.path.join("dsi_template","dsi.pst"),version=2)
+    shutil.copy(os.path.join('ends_master',"pestpp-ies.exe"),
+                os.path.join(t_d,"pestpp-ies.exe"))
+    pyemu.os_utils.run("pestpp-ies dsi.pst",cwd=t_d)
+
 
 
 def plot_freyberg_dsi():
@@ -709,9 +710,31 @@ def plot_freyberg_dsi():
     plt.savefig("dsi_pred.pdf")
 
 
+def dsi_normscoretransform_test():
+    import pyemu
+    test_d = "ends_master"
+    case = "freyberg6_run_ies"
+    pst_name = os.path.join(test_d, case + ".pst")
+    pst = pyemu.Pst(pst_name)
+
+    oe_name = pst_name.replace(".pst", ".0.obs.csv")
+    oe = pyemu.ObservationEnsemble.from_csv(pst=pst, filename=oe_name).iloc[:100, :]
+
+    for name in oe.columns:
+        print("transforming:",name)
+        values = oe._df.loc[:,name].copy()
+        transformed_values, sorted_values, sorted_idxs = pyemu.helpers.normal_score_transform(values) 
+        backtransformed_values = pyemu.helpers.inverse_normal_score_transform(transformed_values,
+                                transformed_values,
+                                sorted_values)
+        
+        diff = backtransformed_values-sorted_values
+        assert max(abs(diff))<1e-7, backtransformed_values
+
 if __name__ == "__main__":
+    dsi_normscoretransform_test()
     #ends_freyberg_dev()
-    ends_freyberg_dsi_test("temp")
+    #ends_freyberg_dsi_test("temp")
     #plot_freyberg_dsi()
     #obscomp_test()
     #alternative_dw()

--- a/autotest/la_tests.py
+++ b/autotest/la_tests.py
@@ -632,6 +632,32 @@ def ends_freyberg_dsi_test(tmp_path):
     pyemu.os_utils.start_workers(t_d,"pestpp-ies","dsi.pst",num_workers=15,worker_root=tmp_path,
                                  master_dir=m_d)
 
+    # run test wtih normal score transform
+    ends.prep_for_dsi(t_d=t_d,apply_normal_score_transform=True)
+
+    pst = pyemu.Pst(os.path.join(t_d,"dsi.pst"))
+    pst.control_data.noptmax = 3
+    pst.write(os.path.join(t_d,"dsi.pst"),version=2)
+    #pyemu.os_utils.run("pestpp-ies dsi.pst",cwd="dsi_template")
+    m_d = os.path.join(tmp_path,"master_dsi")
+    pyemu.os_utils.start_workers(t_d,"pestpp-ies","dsi.pst",num_workers=15,worker_root=tmp_path,
+                                 master_dir=m_d)
+
+    # run test with log-transform
+    pst = pyemu.Pst(pst_name)
+    pst.observation_data["obstransform"] = "log"
+    ends = pyemu.EnDS(pst=pst, sim_ensemble=oe,verbose=True)
+    ends.prep_for_dsi(t_d=t_d,apply_normal_score_transform=False)
+
+    pst = pyemu.Pst(os.path.join(t_d,"dsi.pst"))
+    pst.control_data.noptmax = 3
+    
+    pst.write(os.path.join(t_d,"dsi.pst"),version=2)
+    #pyemu.os_utils.run("pestpp-ies dsi.pst",cwd="dsi_template")
+    m_d = os.path.join(tmp_path,"master_dsi")
+    pyemu.os_utils.start_workers(t_d,"pestpp-ies","dsi.pst",num_workers=15,worker_root=tmp_path,
+                                 master_dir=m_d)
+
 
 def plot_freyberg_dsi():
     import pandas as pd

--- a/autotest/la_tests.py
+++ b/autotest/la_tests.py
@@ -634,6 +634,14 @@ def ends_freyberg_dsi_test(tmp_path):
     pyemu.os_utils.start_workers(t_d,"pestpp-ies","dsi.pst",num_workers=15,worker_root=tmp_path,
                                  master_dir=m_d)
 
+    # run test wtih truncated svd
+    ends.prep_for_dsi(t_d=t_d,truncated_svd=True)
+    pst = pyemu.Pst(os.path.join(t_d,"dsi.pst"))
+    pst.control_data.noptmax = 3
+    pst.write(os.path.join(t_d,"dsi.pst"),version=2)
+    pyemu.os_utils.start_workers(t_d,"pestpp-ies","dsi.pst",num_workers=15,worker_root=tmp_path,
+                                 master_dir=m_d)
+
 
     # run test wtih normal score transform
     ends.prep_for_dsi(t_d=t_d,apply_normal_score_transform=True)

--- a/pyemu/eds.py
+++ b/pyemu/eds.py
@@ -634,7 +634,7 @@ class EnDS(object):
         self.logger.log("saving proj mat")
 
         #pmat = U * S
-        pmat = np.dot(V, np.diag(S))
+        pmat = np.dot(V, S)
         #row_names = ["sing_vec_{0}".format(i) for i in range(pmat.shape[0])]
         pmat = Matrix(x=pmat,col_names=dsi_pnames,row_names=names)
         pmat.col_names = dsi_pnames

--- a/pyemu/eds.py
+++ b/pyemu/eds.py
@@ -584,11 +584,14 @@ class EnDS(object):
 
         if truncated_svd:
             deltad = Matrix.from_dataframe(Z)
-            U, S, V = deltad.pseudo_inv_components(maxsing=Z.shape[0],eigthresh=1e-30)
-            S = np.diag(S)
+            U, S, V = deltad.pseudo_inv_components(maxsing=Z.shape[0],
+                                                   eigthresh=1e-5)
+            S = S.x
+            V = V.x
         else:
             U, S, V = np.linalg.svd(Z.values, full_matrices=False)
             V = V.transpose()
+            S = np.diag(S)
         self.logger.log("pseudo inv of deviations matrix")
 
 

--- a/pyemu/eds.py
+++ b/pyemu/eds.py
@@ -507,6 +507,9 @@ class EnDS(object):
                 variables.  If `None`, use `self.sim_ensemble`.  Default is `None`
             t_d (`str`): template directory to setup the DSI model + pest files in.  Default is `dsi_template`
             apply_normal_score_transform (`bool`): flag to apply a normal score transform to the observations
+                and predictions.  Default is `False`
+            truncated_svd (`bool`): flag to use a truncated SVD for the pseudo-inverse of the deviations matrix.
+                Default is `False`
 
         Example::
 

--- a/pyemu/eds.py
+++ b/pyemu/eds.py
@@ -652,10 +652,9 @@ class EnDS(object):
         self.logger.log("saving proj mat")
 
 
-
-
         # this is the dsi forward run function - it is harded coded below!
         def dsi_forward_run():
+            import os
             import numpy as np
             import pandas as pd
             from pyemu.mat.mat_handler import Matrix

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -4020,294 +4020,158 @@ def apply_threshold_pars(csv_file):
 
 
 
-class Interpolator1d:
-    """Interpolation class for 1D data.
-    Replaces scipy.interpolate.interp1d.
-    
-    Parameters
-    ----------
-    
-    x_points : array-like
-        X-coordinates of the data points.  
-    y_points : array-like
-        Y-coordinates of the data points.
-    kind : str, optional
-        The kind of interpolation to use. Supported kinds: 'linear', 'quadratic', 'cubic'.
-        Default is 'linear'.
-        
-    Attributes
-    ----------
-    
-    x_points : numpy.ndarray
-    y_points : numpy.ndarray
-    kind : str
-    
-    Methods
-    -------
-    
-    interpolate(x_new)
-    
-    Example:
-    interpolator = pyemu.helpers.Interpolator1d(x_points, y_points)
-    y_new = interpolator.interpolate(x_new, kind='linear')
-    
+def randrealgen_optimized(nreal, tol=1e-7, max_samples=1000000):
     """
-    def __init__(self, x_points, y_points):
-        if len(x_points) != len(y_points):
-            raise ValueError("x_points and y_points must have the same length.")
-        
-        self.x_points = np.array(x_points)
-        self.y_points = np.array(y_points)
-
-        # check if there are duplciates of x and y
-        #remove duplicate x values
-        _, idx = np.unique(self.x_points, return_index=True)
-        self.x_points = self.x_points[np.sort(idx)]
-        self.y_points = self.y_points[np.sort(idx)]
-
-    def _linear_extrapolate(self, x):
-        if x < self.x_points[0]:
-            slope = (self.y_points[1] - self.y_points[0]) / (self.x_points[1] - self.x_points[0])
-            return self.y_points[0] + slope * (x - self.x_points[0])
-        elif x > self.x_points[-1]:
-            slope = (self.y_points[-1] - self.y_points[-2]) / (self.x_points[-1] - self.x_points[-2])
-            return self.y_points[-1] + slope * (x - self.x_points[-1])
-        else:
-            return None
-
-    def _quadratic_extrapolate(self, x):
-        if x < self.x_points[0]:
-            x0, x1, x2 = self.x_points[0], self.x_points[1], self.x_points[2]
-            y0, y1, y2 = self.y_points[0], self.y_points[1], self.y_points[2]
-        elif x > self.x_points[-1]:
-            x0, x1, x2 = self.x_points[-3], self.x_points[-2], self.x_points[-1]
-            y0, y1, y2 = self.y_points[-3], self.y_points[-2], self.y_points[-1]
-        else:
-            return None
-
-        # Calculate the coefficients of the quadratic polynomial
-        denom = (x0 - x1) * (x0 - x2) * (x1 - x2)
-        a = (x2 * (y1 - y0) + x1 * (y0 - y2) + x0 * (y2 - y1)) / denom
-        b = (x2**2 * (y0 - y1) + x1**2 * (y2 - y0) + x0**2 * (y1 - y2)) / denom
-        c = (x1 * x2 * (x1 - x2) * y0 + x2 * x0 * (x2 - x0) * y1 + x0 * x1 * (x0 - x1) * y2) / denom
-
-        return a * x**2 + b * x + c
-
-    def _cubic_extrapolate(self, x):
-        if x < self.x_points[0]:
-            x0, x1, x2, x3 = self.x_points[0], self.x_points[1], self.x_points[2], self.x_points[3]
-            y0, y1, y2, y3 = self.y_points[0], self.y_points[1], self.y_points[2], self.y_points[3]
-        elif x > self.x_points[-1]:
-            x0, x1, x2, x3 = self.x_points[-4], self.x_points[-3], self.x_points[-2], self.x_points[-1]
-            y0, y1, y2, y3 = self.y_points[-4], self.y_points[-3], self.y_points[-2], self.y_points[-1]
-        else:
-            return None
-
-        A = np.array([
-            [x0**3, x0**2, x0, 1],
-            [x1**3, x1**2, x1, 1],
-            [x2**3, x2**2, x2, 1],
-            [x3**3, x3**2, x3, 1]
-        ])
-        b = np.array([y0, y1, y2, y3])
-
-        coeffs = np.linalg.solve(A, b)
-        return coeffs[0] * x**3 + coeffs[1] * x**2 + coeffs[2] * x + coeffs[3]
-
-    def interpolate(self, x_new, kind='linear'):
-        if isinstance(x_new, (int, float)):
-            x_new = [x_new]
-
-        if kind == 'linear':
-            return [self._linear_interpolate(x) for x in x_new]
-        elif kind == 'quadratic':
-            return [self._quadratic_interpolate(x) for x in x_new]
-        elif kind == 'cubic':
-            return [self._cubic_interpolate(x) for x in x_new]
-        else:
-            raise ValueError("Unknown interpolation kind. Supported kinds: 'linear', 'quadratic', 'cubic'.")
-
-    def _linear_interpolate(self, x):
-        y = self._linear_extrapolate(x)
-        if y is not None:
-            return y
-        for i in range(1, len(self.x_points)):
-            if x <= self.x_points[i]:
-                slope = (self.y_points[i] - self.y_points[i-1]) / (self.x_points[i] - self.x_points[i-1])
-                return self.y_points[i-1] + slope * (x - self.x_points[i-1])
-
-    def _quadratic_interpolate(self, x):
-        y = self._quadratic_extrapolate(x)
-        if y is not None:
-            return y
-        for i in range(1, len(self.x_points) - 1):
-            if x <= self.x_points[i+1]:
-                x0, x1, x2 = self.x_points[i-1], self.x_points[i], self.x_points[i+1]
-                y0, y1, y2 = self.y_points[i-1], self.y_points[i], self.y_points[i+1]
-                return y0 * (x - x1) * (x - x2) / ((x0 - x1) * (x0 - x2)) + \
-                       y1 * (x - x0) * (x - x2) / ((x1 - x0) * (x1 - x2)) + \
-                       y2 * (x - x0) * (x - x1) / ((x2 - x0) * (x2 - x1))
-
-    def _cubic_interpolate(self, x):
-        y = self._cubic_extrapolate(x)
-        if y is not None:
-            return y
-        for i in range(1, len(self.x_points) - 2):
-            if x <= self.x_points[i+2]:
-                x0, x1, x2, x3 = self.x_points[i-1], self.x_points[i], self.x_points[i+1], self.x_points[i+2]
-                y0, y1, y2, y3 = self.y_points[i-1], self.y_points[i], self.y_points[i+1], self.y_points[i+2]
-                A = np.array([
-                    [x0**3, x0**2, x0, 1],
-                    [x1**3, x1**2, x1, 1],
-                    [x2**3, x2**2, x2, 1],
-                    [x3**3, x3**2, x3, 1]
-                ])
-                b = np.array([y0, y1, y2, y3])
-                coeffs = np.linalg.solve(A, b)
-                return coeffs[0] * x**3 + coeffs[1] * x**2 + coeffs[2] * x + coeffs[3]
-
-
-def norm_cdf(x):
-    """Compute the CDF of the standard normal distribution."""
-    return 0.5 * (1 + math.erf(x / math.sqrt(2)))
-
-def norm_pdf(x):
-    """Compute the PDF of the standard normal distribution."""
-    return (1 / math.sqrt(2 * math.pi)) * math.exp(-0.5 * x * x)
-
-def norm_ppf(p, tol=1e-10, max_iter=100):
-    """
-    Compute the inverse of the cumulative distribution function (CDF)
-    of the standard normal distribution using the Newton-Raphson method.
+    Generate a set of random realizations with a normal distribution.
     
     Parameters:
-    p : float
-        A probability value in the range (0, 1).
+    nreal : int
+        The number of realizations to generate.
     tol : float
         Tolerance for the stopping criterion.
-    max_iter : int
-        Maximum number of iterations.
+    max_samples : int
+        Maximum number of samples to use.
+        
+    Returns:
+    numpy.ndarray
+        An array of nreal random realizations.
+    """
+    rval = np.zeros(nreal)
+    nsamp = 0
+    numsort = (nreal + 1) // 2
+
+    while nsamp < max_samples:
+        nsamp += 1
+        work1 = np.random.normal(size=nreal)
+        work1.sort()
+        
+        if nsamp > 1:
+            previous_mean = rval[:numsort] / (nsamp - 1)
+            rval[:numsort] += work1[:numsort]
+            current_mean = rval[:numsort] / nsamp
+            max_diff = np.max(np.abs(current_mean - previous_mean))
+            
+            if max_diff <= tol:
+                break
+        else:
+            rval[:numsort] = work1[:numsort]
     
+    rval[:numsort] /= nsamp
+    rval[numsort:] = -rval[:numsort][::-1]
+    
+    return rval
+
+
+def normal_score_transform(nstval, val, value):
+    """
+    Transform a value to its normal score using a normal score transform table.
+    
+    Parameters:
+    nstval : array-like
+        Normal score transform table values.
+    val : array-like
+        Original values corresponding to the normal score transform table.
+    value : float
+        The value to transform.
+        
     Returns:
     float
-        The value x such that the CDF of the standard normal distribution at x is p.
-    """
-    if p <= 0.0 or p >= 1.0:
-        raise ValueError("p must be in the range (0, 1)")
+        The normal score of the value.
+    int
+        The index of the value in the normal score transform table."""
+    
+    # make sure the input is numpy arrays
+    val = np.asarray(val)
+    nstval = np.asarray(nstval)
+    
+    # if the value is outside the range of the table, return the first or last value
+    if value <= val[0]:
+        return nstval[0], 0
+    elif value >= val[-1]:
+        return nstval[-1], len(val)
 
-    # Initial guess using an approximation
-    if p < 0.5:
-        initial_guess = -math.sqrt(-2.0 * math.log(p))
+    # find the rank of the value in the table
+    rank = np.searchsorted(val, value, side='right') - 1
+    if rank == len(val) - 1:
+        return nstval[-1], len(val)
+    # if the value conincides with a value in the table, return the corresponding normal score
+    nstdiff = nstval[rank + 1] - nstval[rank]
+    diff = val[rank + 1] - val[rank]
+    if nstdiff <= 0.0 or diff <= 0.0:
+        return nstval[rank], rank
+    
+    # otherwise, interpolate to get the normal score
+    dist = value - val[rank]
+    interpolated_value = nstval[rank] + (dist / diff) * nstdiff
+    return interpolated_value, rank
+
+
+def inverse_normal_score_transform(nstval, val, value, extrap='quadratic'):
+    nreal = len(val)
+    
+    def linear_extrapolate(x0, y0, x1, y1, x):
+        if x1 != x0:
+            return y0 + (y1 - y0) / (x1 - x0) * (x - x0)
+        return y0
+
+    def quadratic_extrapolate(x0, y0, x1, y1, x2, y2, x):
+        denom = (x0 - x) * (x1 - x) * (x2 - x)
+        if denom == 0:
+            print(x, x0, x1, x2)
+            raise ValueError("Input x values must be distinct")
+
+        a = ((x - x1) * (y2 - y1) - (x - x2) * (y1 - y0)) / denom
+        b = ((x - x2) * (y1 - y0) - (x - x0) * (y2 - y1)) / denom
+        c = y0 - a * x0**2 - b * x0
+        y = a * x**2 + b * x + c
+        return y
+
+    ilim = 0
+    if value in nstval:
+        rank = np.searchsorted(nstval, value)
+        value = val[rank]
+
+    elif value < nstval[0]:
+        ilim = -1
+        if extrap is None:
+            value = val[0]
+        elif extrap == 'linear':
+            value = linear_extrapolate(nstval[0], val[0], nstval[1], val[1], value)
+            value = min(value, val[0])
+        elif extrap == 'quadratic' and nreal >= 3:
+            y_vals = np.unique(val)[:3]
+            idxs = np.searchsorted(val,y_vals)
+            x_vals = nstval[idxs]
+            value = quadratic_extrapolate(x_vals[-3], y_vals[-3], x_vals[-2], y_vals[-2], x_vals[-1], y_vals[-1], value)
+            #value = min(value, val[0])
+        else:
+            value = val[0]
+
+    elif value > nstval[-1]:
+        ilim = 1
+        if extrap is None:
+            value = val[-1]
+        elif extrap == 'linear':
+            value = linear_extrapolate(nstval[-2], val[-2], nstval[-1], val[-1], value)
+            value = max(value, val[-1])
+        elif extrap == 'quadratic' and nreal >= 3:
+            y_vals = np.unique(val)[-3:]
+            idxs = np.searchsorted(val,y_vals)
+            x_vals = nstval[idxs]
+            value = quadratic_extrapolate(x_vals[-3], y_vals[-3], x_vals[-2], y_vals[-2], x_vals[-1], y_vals[-1], value)
+            #value = max(value, val[-1])
+        else:
+            value = val[-1]
+
     else:
-        initial_guess = math.sqrt(-2.0 * math.log(1.0 - p))
+        rank = np.searchsorted(nstval, value) - 1
+        nstdiff = nstval[rank + 1] - nstval[rank]
+        diff = val[rank + 1] - val[rank]
+        if nstdiff <= 0.0 or diff <= 0.0:
+            value = val[rank]
+        else:
+            nstdist = value - nstval[rank]
+            value = val[rank] + (nstdist / nstdiff) * diff
     
-    x = initial_guess
-    for _ in range(max_iter):
-        # Compute the function value and its derivative
-        cdf_value = norm_cdf(x)
-        pdf_value = norm_pdf(x)
-        
-        # Newton-Raphson update
-        x_new = x - (cdf_value - p) / pdf_value
-        
-        # Check for convergence
-        if abs(x_new - x) < tol:
-            return x_new
-        
-        x = x_new
-    
-    raise RuntimeError("Convergence not achieved within max_iter iterations")
-
-
-def normal_score_transform(values):
-    """
-    Transforms a pandas Series of values to their normal scores.
-
-    This function first sorts the input values, then computes their ranks and uses these ranks to
-    calculate uniform quantiles. These quantiles are then transformed into normal scores using the
-    inverse of the normal cumulative distribution function (norm_ppf). A linear interpolation is
-    performed to map these normal scores back to the original data distribution, resulting in the
-    transformed values.
-
-    Parameters:
-    values (pd.Series): A pandas Series containing the values to be transformed.This is assumed to come from an Observation Ensemble.
-
-    Returns:
-    tuple: A tuple containing three elements:
-        - transformed_values (np.ndarray): The values transformed to their normal scores.
-        - sorted_values (np.ndarray): The original values sorted in ascending order.
-        - sorted_index (pd.Index): The original index of the sorted values.
-    """
-    #Ensure values are sorted
-    values.sort_values(inplace=True)
-    # get the sorted real/indexes for safe keeping
-    sorted_index = values.index
-    sorted_values = values.values
-    if np.all(sorted_values == sorted_values[0]):
-        print("warning: all values are the same, returning all zeroes")
-        return np.zeros_like(sorted_values), sorted_values, sorted_index
-    #Calucalte the Rank
-    ranks = values.rank(method='average')
-    assert (ranks==np.sort(ranks)).all(), "ranks must be sorted"
-    # the quartiles
-    uniform_quantiles = (ranks - 0.5) / len(values)
-    # and normal scores
-    normal_scores = np.array([norm_ppf(i) for i in uniform_quantiles]) # scipy.stats.norm.ppf(uniform_quantiles)
-    cdf_norm = np.linspace(0,1,len(normal_scores))
-    cdf = np.linspace(0,1,len(values))
-    #Interpoalte to obtain transforemd vlaues
-    interpolator = pyemu.helpers.Interpolator1d(cdf_norm, normal_scores)
-    transformed_values = interpolator.interpolate(cdf, kind='linear')
-    assert (values==np.sort(values)).all(), "sorted values must be sorted"
-    return transformed_values, sorted_values, sorted_index
-
-def inverse_normal_score_transform(gaussian_data, transformed_values, sorted_values):
-    """
-    Transforms Gaussian-distributed data back to its original scale using inverse normal score transformation.
-
-    This function applies an inverse transformation to data that has been previously transformed to a Gaussian
-    distribution. It uses linear interpolation based on sorted transformed values and their corresponding original
-    values to map Gaussian-distributed data back to its original scale.
-
-    Parameters:
-    gaussian_data (np.ndarray): The Gaussian-distributed data to be transformed back to its original scale.
-    transformed_values (np.ndarray): The transformed values that were originally used to map the original data
-                                     to a Gaussian distribution. Must be sorted in ascending order.
-    sorted_values (np.ndarray): The original values corresponding to the transformed_values, sorted in ascending
-                                order. These are used as the target values for interpolation.
-
-    Returns:
-    np.ndarray or float: The back-transformed values in their original scale. Returns a single float if the input
-                         is a single value.
-
-    Raises:
-    AssertionError: If either transformed_values or sorted_values are not sorted in ascending order.
-
-    Note:
-    This function relies on the `Interpolator1d` class from the `pyemu.helpers` module for performing the
-    interpolation.
-    """
-
-    # check if all values in transformed_values and in sorted_values are the same
-    # if so, dont bother interpolating
-    if np.all(sorted_values == sorted_values[0]):
-        if np.all(transformed_values == transformed_values[0]):
-            return sorted_values[:len(gaussian_data)]
-
-    # interpolate back to data-space
-    interpolator = pyemu.helpers.Interpolator1d(transformed_values, sorted_values)
-    back_trasformed_values = interpolator.interpolate(gaussian_data, kind='linear')
-    # if single value, return as float 
-    if len(back_trasformed_values)==1:
-        back_trasformed_values = back_trasformed_values[0]
-    return back_trasformed_values
-
-
-
-
-
-
-
-
-
+    return value, ilim
 

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -4019,7 +4019,273 @@ def apply_threshold_pars(csv_file):
 
 
 
+class Interpolator1d:
+    """Interpolation class for 1D data.
+    Replaces scipy.interpolate.interp1d.
+    
+    Parameters
+    ----------
+    
+    x_points : array-like
+        X-coordinates of the data points.  
+    y_points : array-like
+        Y-coordinates of the data points.
+    kind : str, optional
+        The kind of interpolation to use. Supported kinds: 'linear', 'quadratic', 'cubic'.
+        Default is 'linear'.
+        
+    Attributes
+    ----------
+    
+    x_points : numpy.ndarray
+    y_points : numpy.ndarray
+    kind : str
+    
+    Methods
+    -------
+    
+    interpolate(x_new)
+    
+    Example:
+    interpolator = pyemu.helpers.Interpolator1d(x_points, y_points)
+    y_new = interpolator.interpolate(x_new, kind='linear')
+    
+    """
+    def __init__(self, x_points, y_points):
+        if len(x_points) != len(y_points):
+            raise ValueError("x_points and y_points must have the same length.")
+        
+        self.x_points = np.array(x_points)
+        self.y_points = np.array(y_points)
 
+    def _linear_extrapolate(self, x):
+        if x < self.x_points[0]:
+            slope = (self.y_points[1] - self.y_points[0]) / (self.x_points[1] - self.x_points[0])
+            return self.y_points[0] + slope * (x - self.x_points[0])
+        elif x > self.x_points[-1]:
+            slope = (self.y_points[-1] - self.y_points[-2]) / (self.x_points[-1] - self.x_points[-2])
+            return self.y_points[-1] + slope * (x - self.x_points[-1])
+        else:
+            return None
+
+    def _quadratic_extrapolate(self, x):
+        if x < self.x_points[0]:
+            x0, x1, x2 = self.x_points[0], self.x_points[1], self.x_points[2]
+            y0, y1, y2 = self.y_points[0], self.y_points[1], self.y_points[2]
+        elif x > self.x_points[-1]:
+            x0, x1, x2 = self.x_points[-3], self.x_points[-2], self.x_points[-1]
+            y0, y1, y2 = self.y_points[-3], self.y_points[-2], self.y_points[-1]
+        else:
+            return None
+
+        a = (y2 - (y1 - y0) * (x2 - x0) / (x1 - x0)) / ((x2 - x0) * (x2 - x1))
+        b = (y1 - y0) / (x1 - x0) - a * (x1 + x0)
+        c = y0 - a * x0 * x0 - b * x0
+
+        return a * x**2 + b * x + c
+
+    def _cubic_extrapolate(self, x):
+        if x < self.x_points[0]:
+            x0, x1, x2, x3 = self.x_points[0], self.x_points[1], self.x_points[2], self.x_points[3]
+            y0, y1, y2, y3 = self.y_points[0], self.y_points[1], self.y_points[2], self.y_points[3]
+        elif x > self.x_points[-1]:
+            x0, x1, x2, x3 = self.x_points[-4], self.x_points[-3], self.x_points[-2], self.x_points[-1]
+            y0, y1, y2, y3 = self.y_points[-4], self.y_points[-3], self.y_points[-2], self.y_points[-1]
+        else:
+            return None
+
+        A = np.array([
+            [x0**3, x0**2, x0, 1],
+            [x1**3, x1**2, x1, 1],
+            [x2**3, x2**2, x2, 1],
+            [x3**3, x3**2, x3, 1]
+        ])
+        b = np.array([y0, y1, y2, y3])
+
+        coeffs = np.linalg.solve(A, b)
+        return coeffs[0] * x**3 + coeffs[1] * x**2 + coeffs[2] * x + coeffs[3]
+
+    def interpolate(self, x_new, kind='linear'):
+        if isinstance(x_new, (int, float)):
+            x_new = [x_new]
+
+        if kind == 'linear':
+            return [self._linear_interpolate(x) for x in x_new]
+        elif kind == 'quadratic':
+            return [self._quadratic_interpolate(x) for x in x_new]
+        elif kind == 'cubic':
+            return [self._cubic_interpolate(x) for x in x_new]
+        else:
+            raise ValueError("Unknown interpolation kind. Supported kinds: 'linear', 'quadratic', 'cubic'.")
+
+    def _linear_interpolate(self, x):
+        y = self._linear_extrapolate(x)
+        if y is not None:
+            return y
+        for i in range(1, len(self.x_points)):
+            if x <= self.x_points[i]:
+                slope = (self.y_points[i] - self.y_points[i-1]) / (self.x_points[i] - self.x_points[i-1])
+                return self.y_points[i-1] + slope * (x - self.x_points[i-1])
+
+    def _quadratic_interpolate(self, x):
+        y = self._quadratic_extrapolate(x)
+        if y is not None:
+            return y
+        for i in range(1, len(self.x_points) - 1):
+            if x <= self.x_points[i+1]:
+                x0, x1, x2 = self.x_points[i-1], self.x_points[i], self.x_points[i+1]
+                y0, y1, y2 = self.y_points[i-1], self.y_points[i], self.y_points[i+1]
+                return y0 * (x - x1) * (x - x2) / ((x0 - x1) * (x0 - x2)) + \
+                       y1 * (x - x0) * (x - x2) / ((x1 - x0) * (x1 - x2)) + \
+                       y2 * (x - x0) * (x - x1) / ((x2 - x0) * (x2 - x1))
+
+    def _cubic_interpolate(self, x):
+        y = self._cubic_extrapolate(x)
+        if y is not None:
+            return y
+        for i in range(1, len(self.x_points) - 2):
+            if x <= self.x_points[i+2]:
+                x0, x1, x2, x3 = self.x_points[i-1], self.x_points[i], self.x_points[i+1], self.x_points[i+2]
+                y0, y1, y2, y3 = self.y_points[i-1], self.y_points[i], self.y_points[i+1], self.y_points[i+2]
+                A = np.array([
+                    [x0**3, x0**2, x0, 1],
+                    [x1**3, x1**2, x1, 1],
+                    [x2**3, x2**2, x2, 1],
+                    [x3**3, x3**2, x3, 1]
+                ])
+                b = np.array([y0, y1, y2, y3])
+                coeffs = np.linalg.solve(A, b)
+                return coeffs[0] * x**3 + coeffs[1] * x**2 + coeffs[2] * x + coeffs[3]
+
+
+def norm_cdf(x):
+    """Compute the CDF of the standard normal distribution."""
+    return 0.5 * (1 + math.erf(x / math.sqrt(2)))
+
+def norm_pdf(x):
+    """Compute the PDF of the standard normal distribution."""
+    return (1 / math.sqrt(2 * math.pi)) * math.exp(-0.5 * x * x)
+
+def norm_ppf(p, tol=1e-10, max_iter=100):
+    """
+    Compute the inverse of the cumulative distribution function (CDF)
+    of the standard normal distribution using the Newton-Raphson method.
+    
+    Parameters:
+    p : float
+        A probability value in the range (0, 1).
+    tol : float
+        Tolerance for the stopping criterion.
+    max_iter : int
+        Maximum number of iterations.
+    
+    Returns:
+    float
+        The value x such that the CDF of the standard normal distribution at x is p.
+    """
+    if p <= 0.0 or p >= 1.0:
+        raise ValueError("p must be in the range (0, 1)")
+
+    # Initial guess using an approximation
+    if p < 0.5:
+        initial_guess = -math.sqrt(-2.0 * math.log(p))
+    else:
+        initial_guess = math.sqrt(-2.0 * math.log(1.0 - p))
+    
+    x = initial_guess
+    for _ in range(max_iter):
+        # Compute the function value and its derivative
+        cdf_value = norm_cdf(x)
+        pdf_value = norm_pdf(x)
+        
+        # Newton-Raphson update
+        x_new = x - (cdf_value - p) / pdf_value
+        
+        # Check for convergence
+        if abs(x_new - x) < tol:
+            return x_new
+        
+        x = x_new
+    
+    raise RuntimeError("Convergence not achieved within max_iter iterations")
+
+
+def normal_score_transform(values):
+    """
+    Transforms a pandas Series of values to their normal scores.
+
+    This function first sorts the input values, then computes their ranks and uses these ranks to
+    calculate uniform quantiles. These quantiles are then transformed into normal scores using the
+    inverse of the normal cumulative distribution function (norm_ppf). A linear interpolation is
+    performed to map these normal scores back to the original data distribution, resulting in the
+    transformed values.
+
+    Parameters:
+    values (pd.Series): A pandas Series containing the values to be transformed.This is assumed to come from an Observation Ensemble.
+
+    Returns:
+    tuple: A tuple containing three elements:
+        - transformed_values (np.ndarray): The values transformed to their normal scores.
+        - sorted_values (np.ndarray): The original values sorted in ascending order.
+        - sorted_index (pd.Index): The original index of the sorted values.
+    """
+    #Ensure values are sorted
+    values.sort_values(inplace=True)
+    # get the sorted real/indexes for safe keeping
+    sorted_index = values.index
+    sorted_values = values.values
+    #Calucalte the Rank
+    ranks = values.rank(method='average')
+    assert (ranks==np.sort(ranks)).all(), "ranks must be sorted"
+    # the quartiles
+    uniform_quantiles = (ranks - 0.5) / len(values)
+    # and normal scores
+    normal_scores = np.array([norm_ppf(i) for i in uniform_quantiles]) # scipy.stats.norm.ppf(uniform_quantiles)
+    cdf_norm = np.linspace(0,1,len(normal_scores))
+    cdf = np.linspace(0,1,len(values))
+    #Interpoalte to obtain transforemd vlaues
+    interpolator = pyemu.helpers.Interpolator1d(cdf_norm, normal_scores)
+    transformed_values = interpolator.interpolate(cdf, kind='linear')
+    assert (values==np.sort(values)).all(), "sorted values must be sorted"
+    return transformed_values, sorted_values, sorted_index
+
+def inverse_normal_score_transform(gaussian_data, transformed_values, sorted_values):
+    """
+    Transforms Gaussian-distributed data back to its original scale using inverse normal score transformation.
+
+    This function applies an inverse transformation to data that has been previously transformed to a Gaussian
+    distribution. It uses linear interpolation based on sorted transformed values and their corresponding original
+    values to map Gaussian-distributed data back to its original scale.
+
+    Parameters:
+    gaussian_data (np.ndarray): The Gaussian-distributed data to be transformed back to its original scale.
+    transformed_values (np.ndarray): The transformed values that were originally used to map the original data
+                                     to a Gaussian distribution. Must be sorted in ascending order.
+    sorted_values (np.ndarray): The original values corresponding to the transformed_values, sorted in ascending
+                                order. These are used as the target values for interpolation.
+
+    Returns:
+    np.ndarray or float: The back-transformed values in their original scale. Returns a single float if the input
+                         is a single value.
+
+    Raises:
+    AssertionError: If either transformed_values or sorted_values are not sorted in ascending order.
+
+    Note:
+    This function relies on the `Interpolator1d` class from the `pyemu.helpers` module for performing the
+    interpolation.
+    """
+    # check that transformed values are sorted
+    assert (transformed_values==np.sort(transformed_values)).all(), "transformed_values must be sorted"
+    assert (sorted_values==np.sort(sorted_values)).all(), f"sorted values must be sorted{(sorted_values-np.sort(sorted_values))}"
+    
+    # interpolate back to data-space
+    interpolator = pyemu.helpers.Interpolator1d(transformed_values, sorted_values)
+    back_trasformed_values = interpolator.interpolate(gaussian_data, kind='linear')
+    # if single value, return as float 
+    if len(back_trasformed_values)==1:
+        back_trasformed_values = back_trasformed_values[0]
+    return back_trasformed_values
 
 
 

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -15,6 +15,7 @@ import traceback
 import re
 import numpy as np
 import pandas as pd
+import math
 
 pd.options.display.max_colwidth = 100
 from ..pyemu_warnings import PyemuWarning


### PR DESCRIPTION
Allows for users to specify normal-score transformation and/or log-transformation of observation data when calling `pyemu.EnDS.prep_for_dsi()`.

Notes:

- included python native 1D interpolation Class in helpers with the sole purpose of avoiding `from scipy.interpolate import interp1d`. I stress tested against `scipy`'s `interp1d`. Differences start to creep in when extrapolating far from the original x-values. It may be worth using `scipy` instead (or someone smarter than me taking a crack at it...).