### PR TITLE
quick fix to en from parfiles when not all pars are in parfiles

### DIFF
--- a/pyemu/en.py
+++ b/pyemu/en.py
@@ -1346,7 +1346,7 @@ class ParameterEnsemble(Ensemble):
                     ),
                     PyemuWarning,
                 )
-                blank_df = pd.DataFrame(index=df_all.index, columns=diff)
+                blank_df = pd.DataFrame(index=df_all.index, columns=list(diff))
 
                 df_all = pd.concat([df_all, blank_df], axis=1)
 


### PR DESCRIPTION
+ added test for check shape of ensemble generated from par files...
aimed at fixing #524. 
Note, if pars are in control file but not in par files they will be in the ensemble as nan values -- assume this is the behaviour that we want? -- Some downstream filling may be required, before writing, to use with PEST(++)? If they are in the par files but not in the control file only the control file parnmes will appear in the ensemble.