### PR TITLE
refactoring to better support numpy v2 changes

### DIFF
--- a/autotest/en_tests.py
+++ b/autotest/en_tests.py
@@ -206,7 +206,7 @@ def dropna_test():
     pst = pyemu.Pst(os.path.join("pst", "pest.pst"))
     num_reals = 10
     pe = pyemu.ParameterEnsemble.from_gaussian_draw(pst, num_reals=num_reals)
-    pe.iloc[::3,:] = np.NaN
+    pe.iloc[::3,:] = np.nan
     ped = pe.dropna()
     assert type(ped) == pyemu.ParameterEnsemble
     assert ped.shape == pe._df.dropna().shape

--- a/autotest/mc_tests_ignore.py
+++ b/autotest/mc_tests_ignore.py
@@ -543,16 +543,16 @@ def ensemble_covariance_test():
     ecov = peh.covariance_matrix(localizer=localizer)
 
     d = 100.0 * (np.abs((cov - ecov).x) / cov.x)
-    d[localizer==0.0] = np.NaN
+    d[localizer==0.0] = np.nan
 
     assert np.nanmax(d) < 10.0
 
     # import matplotlib.pyplot as plt
     #
     # cov = cov.x
-    # cov[localizer == 0.0] = np.NaN
+    # cov[localizer == 0.0] = np.nan
     # ecov = ecov.x
-    # ecov[localizer == 0.0] = np.NaN
+    # ecov[localizer == 0.0] = np.nan
     #
     # ax = plt.subplot(311)
     # ax2 = plt.subplot(312)

--- a/autotest/pst_from_tests.py
+++ b/autotest/pst_from_tests.py
@@ -4775,12 +4775,21 @@ def list_float_int_index_test(tmp_path):
                       use_cols=["ghbcondN"],
                       lower_bound=0.01,
                       upper_bound=100)
+    pf.add_parameters(filenames="ghb_ppt_part1.dat",
+                      par_type="grid",
+                      par_name_base=["n2"],
+                      index_cols=ghbidx,
+                      use_cols=["ghbcondN"],
+                      use_rows=[(29, 1920172.116, 5610676.98),
+                                ('pt38', 1914756.535, 5605938.218)],
+                      lower_bound=0.01,
+                      upper_bound=100)
     pf.add_observations(filename="ghb_ppt_part1.dat",
                         index_cols=ghbidx,
                         use_cols="ghbcondN")
     pst = pf.build_pst()
     par = pst.parameter_data
-    assert par.shape[0] == faultdf_o.shape[0] * 5 + len(ghbdf_o)
+    assert par.shape[0] == faultdf_o.shape[0] * 5 + len(ghbdf_o) + 2
     obs = pst.observation_data
     assert obs.shape[0] == faultdf_o.shape[0] * 5 + len(ghbdf_o)
     # pf.parfile_relations.to_csv(os.path.join(pf.new_d,"mult2model_info.csv"))
@@ -4810,7 +4819,7 @@ def list_float_int_index_test(tmp_path):
     idxcheck = ghbdf_n.set_index(ghbidx).index.difference(ghbdf_o.set_index(ghbidx).index)
     assert len(idxcheck) == 0, idxcheck
     diff = (ghbdf_n.set_index(ghbidx).ghbcondN/ghbdf_o.set_index(ghbidx).ghbcondN).sort_index(level=0)
-    bparval1 = par.loc[bpar].sort_values('ppt').parval1.values
+    bparval1 = par.loc[bpar].sort_values('ppt').groupby(ghbidx).parval1.prod()
     assert np.isclose(diff,bparval1).all(), diff.loc[~np.isclose(diff,bparval1)]
 
 

--- a/autotest/pst_tests.py
+++ b/autotest/pst_tests.py
@@ -619,13 +619,13 @@ def try_process_ins_test():
     ins_file = os.path.join("utils", "BH.mt3d.processed.ins")
     i = pyemu.pst_utils.InstructionFile(ins_file)
     df2 = i.read_output_file(ins_file.replace(".ins",""))
-    df2.loc[df2.obsval>1.0e+10,"obsval"] = np.NaN
+    df2.loc[df2.obsval>1.0e+10,"obsval"] = np.nan
 
 
     # df1 = pyemu.pst_utils._try_run_inschek(ins_file,ins_file.replace(".ins",""))
     df1 = pd.read_csv(ins_file.replace(".ins", ".obf"), sep=r"\s+",
                       names=["obsnme", "obsval"], index_col=0)
-    df1.loc[df1.obsval > 1.0e+10, "obsval"] = np.NaN
+    df1.loc[df1.obsval > 1.0e+10, "obsval"] = np.nan
     print(df1.max())
     print(df2.max())
     # df1.index = df1.obsnme
@@ -873,7 +873,7 @@ def new_format_test(tmp_path):
         assert len(pst.instruction_files) == len(pst_new.instruction_files)
         assert len(pst.output_files) == len(pst_new.output_files)
 
-    pst_new.parameter_groups.loc[:,:] = np.NaN
+    pst_new.parameter_groups.loc[:,:] = np.nan
     pst_new.parameter_groups.dropna(inplace=True)
     pst_new.write(os.path.join(tmp_path, "test.pst"), version=2)
     pst_new = pyemu.Pst(os.path.join(tmp_path, "test.pst"))
@@ -1118,7 +1118,7 @@ def write2_nan_test(tmp_path):
     os.chdir(tmp_path)
     try:
         pyemu.helpers.zero_order_tikhonov(pst)
-        pst.prior_information.loc[pst.prior_names[0], "weight"] = np.NaN
+        pst.prior_information.loc[pst.prior_names[0], "weight"] = np.nan
         _try_write2fail(pst, newpst_f, order=[1,2])
     except Exception as e:
         os.chdir(bd)
@@ -1126,7 +1126,7 @@ def write2_nan_test(tmp_path):
     os.chdir(bd)
 
     pst = pyemu.Pst(os.path.join("pst", "pest.pst"))
-    pst.model_output_data.loc[pst.instruction_files[0], "pest_file"] = np.NaN
+    pst.model_output_data.loc[pst.instruction_files[0], "pest_file"] = np.nan
     os.chdir(tmp_path)
     try:
         _try_write2fail(pst, newpst_f, order=[1,2])
@@ -1136,7 +1136,7 @@ def write2_nan_test(tmp_path):
     os.chdir(bd)
 
     pst = pyemu.Pst(os.path.join("pst", "pest.pst"))
-    pst.model_input_data.loc[pst.template_files[0], "pest_file"] = np.NaN
+    pst.model_input_data.loc[pst.template_files[0], "pest_file"] = np.nan
     os.chdir(tmp_path)
     try:
         _try_write2fail(pst, newpst_f, order=[1,2])
@@ -1146,7 +1146,7 @@ def write2_nan_test(tmp_path):
     os.chdir(bd)
 
     pst = pyemu.Pst(os.path.join("pst","pest.pst"))
-    pst.parameter_data.loc[pst.par_names[0],"parval1"] = np.NaN
+    pst.parameter_data.loc[pst.par_names[0],"parval1"] = np.nan
     os.chdir(tmp_path)
     try:
         _try_write2fail(pst, newpst_f)
@@ -1157,7 +1157,7 @@ def write2_nan_test(tmp_path):
 
     pst = pyemu.Pst(os.path.join("pst", "pest.pst"))
     idx = pst.parameter_groups.pargpnme.iloc[0]
-    pst.parameter_groups.loc[idx, "derinc"] = np.NaN
+    pst.parameter_groups.loc[idx, "derinc"] = np.nan
     os.chdir(tmp_path)
     try:
         _try_write2fail(pst, newpst_f, order=[2, 1])
@@ -1167,7 +1167,7 @@ def write2_nan_test(tmp_path):
     os.chdir(bd)
 
     pst = pyemu.Pst(os.path.join("pst", "pest.pst"))
-    pst.observation_data.loc[pst.obs_names[0], "weight"] = np.NaN
+    pst.observation_data.loc[pst.obs_names[0], "weight"] = np.nan
     os.chdir(tmp_path)
     try:
         _try_write2fail(pst, newpst_f)

--- a/autotest/pst_tests_2.py
+++ b/autotest/pst_tests_2.py
@@ -153,8 +153,8 @@ def from_flopy(tmp_path):
     ph.pst.write_input_files()
     csv = os.path.join("arr_pars.csv")
     df = pd.read_csv(csv,index_col=0)
-    df.loc[:, "upper_bound"] = np.NaN
-    df.loc[:, "lower_bound"] = np.NaN
+    df.loc[:, "upper_bound"] = np.nan
+    df.loc[:, "lower_bound"] = np.nan
     df.to_csv(csv)
     pyemu.helpers.apply_array_pars()
 
@@ -163,7 +163,7 @@ def from_flopy(tmp_path):
     # #df.loc[:, "org_file"] = df.org_file.iloc[0]
     # #df.loc[:, "model_file"] = df.org_file
     # df.loc[:, "upper_bound"] = np.arange(df.shape[0])
-    # df.loc[:, "lower_bound"] = np.NaN
+    # df.loc[:, "lower_bound"] = np.nan
     # print(df)
     # df.to_csv(csv)
     # try:
@@ -173,7 +173,7 @@ def from_flopy(tmp_path):
     # else:
     #     raise Exception()
     # df.loc[:, "lower_bound"] = np.arange(df.shape[0])
-    # df.loc[:, "upper_bound"] = np.NaN
+    # df.loc[:, "upper_bound"] = np.nan
     # print(df)
     # df.to_csv(csv)
     # try:

--- a/autotest/utils_tests.py
+++ b/autotest/utils_tests.py
@@ -680,10 +680,10 @@ def ppk2fac_verf_test(tmp_path):
 
     pyemu_arr = pyemu.utils.fac2real(pp_file,pyemu_facfile,out_file=None)
     ppk2fac_arr = pyemu.utils.fac2real(pp_file,ppk2fac_facfile,out_file=None)
-    pyemu_arr[zone_arr == 0] = np.NaN
-    pyemu_arr[zone_arr == -1] = np.NaN
-    ppk2fac_arr[zone_arr == 0] = np.NaN
-    ppk2fac_arr[zone_arr == -1] = np.NaN
+    pyemu_arr[zone_arr == 0] = np.nan
+    pyemu_arr[zone_arr == -1] = np.nan
+    ppk2fac_arr[zone_arr == 0] = np.nan
+    ppk2fac_arr[zone_arr == -1] = np.nan
 
     diff = np.abs(pyemu_arr - ppk2fac_arr)
     print(diff)
@@ -1175,7 +1175,7 @@ def grid_obs_test(tmp_path):
         assert np.allclose(df1.obsval, df2.obsval), abs(diff.max())
 
         # skip = lambda x : x < -888.0
-        skip = lambda x: x if x > -888.0 else np.NaN
+        skip = lambda x: x if x > -888.0 else np.nan
         pyemu.gw_utils.setup_hds_obs(hds_file,skip=skip)
         df1 = pd.read_csv(out_file,sep=r"\s+",)
         pyemu.gw_utils.apply_hds_obs(hds_file)
@@ -2176,13 +2176,13 @@ def geostat_prior_builder2_test(tmp_path):
     ecov2 = pe.covariance_matrix()
 
     x1 = cov1.x.copy()
-    x1[np.abs(cov1.to_pearson().x)<0.001] = np.NaN
+    x1[np.abs(cov1.to_pearson().x)<0.001] = np.nan
     x2 = cov2.x.copy()
-    x2[np.abs(cov2.to_pearson().x) < 0.001] = np.NaN
+    x2[np.abs(cov2.to_pearson().x) < 0.001] = np.nan
     ex2 = ecov2.x.copy()
-    ex2[np.abs(ecov2.to_pearson().x) < 0.001] = np.NaN
+    ex2[np.abs(ecov2.to_pearson().x) < 0.001] = np.nan
     x3 = cov3.x.copy()
-    x3[np.abs(cov3.to_pearson().x) < 0.001] = np.NaN
+    x3[np.abs(cov3.to_pearson().x) < 0.001] = np.nan
 
     # even tho we scaled cov2, the resulting corr coef matrix should be the same as cov1
     d = np.abs(cov1.to_pearson().x - cov2.to_pearson().x)

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -19,9 +19,6 @@ dependencies:
   - nbmake
   - shapely
   - pyproj
-#  - flopy
+  - flopy
   - modflow-devtools
   - scikit-learn
-  - pip
-  - pip:
-      - git+https://github.com/modflowpy/flopy@develop

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -19,6 +19,9 @@ dependencies:
   - nbmake
   - shapely
   - pyproj
-  - flopy
+#  - flopy
   - modflow-devtools
   - scikit-learn
+  - pip
+  - pip:
+      - flopy

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -19,9 +19,7 @@ dependencies:
   - nbmake
   - shapely
   - pyproj
-#  - flopy
+  - flopy
   - modflow-devtools
   - scikit-learn
-  - pip
-  - pip:
-      - flopy
+#  - pip

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   # required
   - python>=3.8
-  - numpy<2.0
+  - numpy
   - pandas
   # optional
   - matplotlib
@@ -19,6 +19,9 @@ dependencies:
   - nbmake
   - shapely
   - pyproj
-  - flopy
+#  - flopy
   - modflow-devtools
   - scikit-learn
+  - pip
+  - pip:
+      - git+https://github.com/modflowpy/flopy@develop

--- a/examples/MODFLOW_to_PEST_even_more_boss.ipynb
+++ b/examples/MODFLOW_to_PEST_even_more_boss.ipynb
@@ -336,7 +336,7 @@
    "outputs": [],
    "source": [
     "cov = cov.x\n",
-    "cov[cov==0] = np.NaN\n",
+    "cov[cov==0] = np.nan\n",
     "plt.imshow(cov)"
    ]
   },
@@ -410,7 +410,7 @@
    "outputs": [],
    "source": [
     "x = cov.x\n",
-    "x[x==0.0] = np.NaN\n",
+    "x[x==0.0] = np.nan\n",
     "plt.imshow(x)"
    ]
   }
@@ -432,7 +432,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/examples/Schurexample_freyberg.ipynb
+++ b/examples/Schurexample_freyberg.ipynb
@@ -330,7 +330,7 @@
     "# setting the array values that are still -1 \n",
     "# (e.g. no percent reduction value in the cell)\n",
     "# to np.NaN so that they don't get displayed on the plot\n",
-    "unc_array[unc_array == -1] = np.NaN\n",
+    "unc_array[unc_array == -1] = np.nan\n",
     "\n",
     "# plot some model attributes\n",
     "extent=ml.modelgrid.extent\n",
@@ -402,7 +402,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "source": [
     "\n",
@@ -750,7 +753,7 @@
     "        for i,j,unc in zip(df_worth_csp.i,df_worth_csp.j,\n",
     "                           df_worth_csp[forecast_name]):\n",
     "            unc_array[i,j] = unc \n",
-    "        unc_array[unc_array == -1] = np.NaN\n",
+    "        unc_array[unc_array == -1] = np.nan\n",
     "        axlist.append(plt.subplot(111,aspect=\"equal\"))\n",
     "#         cb = axlist[-1].imshow(unc_array,interpolation=\"nearest\",\n",
     "#                                alpha=0.5,extent=ml.modelgrid.extent, \n",
@@ -858,7 +861,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -872,9 +875,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/examples/pstfrom_mf6.ipynb
+++ b/examples/pstfrom_mf6.ipynb
@@ -41,9 +41,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "org_model_ws = os.path.join('freyberg_mf6')\n",
@@ -83,9 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tmp_model_ws = \"temp_pst_from\"\n",
@@ -372,9 +368,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "with open(os.path.join(template_ws,\"hk_layer_1_inst0_grid.csv.tpl\"),'r') as f:\n",
@@ -702,7 +696,7 @@
     "pst = pf.build_pst()\n",
     "cov = pf.build_prior()\n",
     "x = cov.x.copy()\n",
-    "x[x<0.00001] = np.NaN\n",
+    "x[x<0.00001] = np.nan\n",
     "plt.imshow(x)"
    ]
   },
@@ -755,9 +749,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# build up a container of stress period start datetimes - this will\n",
@@ -783,7 +775,7 @@
     "pst = pf.build_pst()\n",
     "cov = pf.build_prior(fmt=\"none\") # skip saving to a file...\n",
     "x = cov.x.copy()\n",
-    "x[x==0] = np.NaN\n",
+    "x[x==0] = np.nan\n",
     "plt.imshow(x)"
    ]
   },
@@ -817,9 +809,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pf.add_parameters(filenames=wel_files,par_type=\"grid\",par_name_base=\"wel_gr\",\n",
@@ -838,7 +828,7 @@
     "pst = pf.build_pst()\n",
     "cov = pf.build_prior(fmt=\"none\")\n",
     "x = cov.x.copy()\n",
-    "x[x==0] = np.NaN\n",
+    "x[x==0] = np.nan\n",
     "plt.imshow(x[-49:,-49:])"
    ]
   },
@@ -1011,9 +1001,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# load the mf6 model with flopy to get the spatial reference\n",
@@ -1212,7 +1200,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1226,7 +1214,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/pyemu/en.py
+++ b/pyemu/en.py
@@ -456,7 +456,7 @@ class Ensemble(object):
             }
             snv = np.random.randn(num_reals, mean_values.shape[0])
             reals = np.zeros_like(snv)
-            reals[:, :] = np.NaN
+            reals[:, :] = np.nan
             for i, name in enumerate(mean_values.index):
                 if name in cov_names:
                     reals[:, i] = (snv[:, i] * stds[name]) + mean_values.loc[name]
@@ -464,7 +464,7 @@ class Ensemble(object):
                     reals[:, i] = mean_values.loc[name]
         else:
             reals = np.zeros((num_reals, mean_values.shape[0]))
-            reals[:, :] = np.NaN
+            reals[:, :] = np.nan
             if fill:
                 for i, v in enumerate(mean_values.values):
                     reals[:, i] = v
@@ -1052,7 +1052,7 @@ class ParameterEnsemble(Ensemble):
         #              for i in range(num_reals)]
         real_names = np.arange(num_reals, dtype=np.int64)
         arr = np.empty((num_reals, len(ub)))
-        arr[:, :] = np.NaN
+        arr[:, :] = np.nan
         adj_par_names = set(pst.adj_par_names)
         for i, pname in enumerate(pst.parameter_data.parnme):
             # print(pname, lb[pname], ub[pname])
@@ -1112,7 +1112,7 @@ class ParameterEnsemble(Ensemble):
 
         real_names = np.arange(num_reals, dtype=np.int64)
         arr = np.empty((num_reals, len(ub)))
-        arr[:, :] = np.NaN
+        arr[:, :] = np.nan
         adj_par_names = set(pst.adj_par_names)
         if len(adj_par_names) == 0:
             warnings.warn("ParameterEnsemble.from_uniform_draw(): no adj pars",PyemuWarning)
@@ -1266,7 +1266,7 @@ class ParameterEnsemble(Ensemble):
 
         df = pd.DataFrame(index=np.arange(num_reals), columns=par_org.parnme.values)
 
-        df.loc[:, :] = np.NaN
+        df.loc[:, :] = np.nan
         if fill:
             fixed_tied = par_org.loc[
                 par_org.partrans.apply(lambda x: x in ["fixed", "tied"]), "parval1"
@@ -1689,7 +1689,7 @@ class ParameterEnsemble(Ensemble):
                 lb - self._df.loc[ridx, :]
             ).max() > 0.0:
                 drop.append(ridx)
-        self.loc[drop, :] = np.NaN
+        self.loc[drop, :] = np.nan
         self.dropna(inplace=True)
 
     def _enforce_reset(self, bound_tol):

--- a/pyemu/legacy/pstfromflopy.py
+++ b/pyemu/legacy/pstfromflopy.py
@@ -1541,7 +1541,7 @@ class PstFromFlopyModel(object):
         pp_dfs_k = {}
         fac_files = {}
         pp_processed = set()
-        pp_df.loc[:, "fac_file"] = np.NaN
+        pp_df.loc[:, "fac_file"] = np.nan
         for pg in pargp:
             ks = pp_df.loc[pp_df.pargp == pg, "k"].unique()
             if len(ks) == 0:
@@ -1640,8 +1640,8 @@ class PstFromFlopyModel(object):
         out_files = mlt_df.loc[
             mlt_df.mlt_file.apply(lambda x: x.endswith(self.pp_suffix)), "mlt_file"
         ]
-        # mlt_df.loc[:,"fac_file"] = np.NaN
-        # mlt_df.loc[:,"pp_file"] = np.NaN
+        # mlt_df.loc[:,"fac_file"] = np.nan
+        # mlt_df.loc[:,"pp_file"] = np.nan
         for out_file in out_files:
             pp_df_pf = pp_df.loc[pp_df.out_file == out_file, :]
             fac_files = pp_df_pf.fac_file
@@ -1664,7 +1664,7 @@ class PstFromFlopyModel(object):
 
         self.par_dfs[self.pp_suffix] = pp_df
 
-        mlt_df.loc[mlt_df.suffix == self.pp_suffix, "tpl_file"] = np.NaN
+        mlt_df.loc[mlt_df.suffix == self.pp_suffix, "tpl_file"] = np.nan
 
     def _kl_prep(self, mlt_df):
         """prepare KL based parameterizations"""
@@ -1732,7 +1732,7 @@ class PstFromFlopyModel(object):
             mlt_df.loc[mlt_df.prefix == prefix, "pp_upper_limit"] = 1.0e10
 
         print(kl_mlt_df)
-        mlt_df.loc[mlt_df.suffix == self.kl_suffix, "tpl_file"] = np.NaN
+        mlt_df.loc[mlt_df.suffix == self.kl_suffix, "tpl_file"] = np.nan
         self.par_dfs[self.kl_suffix] = kl_df
         # calc factors for each layer
 
@@ -1744,7 +1744,7 @@ class PstFromFlopyModel(object):
         mlt_df.loc[:, "tpl_file"] = mlt_df.mlt_file.apply(
             lambda x: os.path.split(x)[-1] + ".tpl"
         )
-        # mlt_df.loc[mlt_df.tpl_file.apply(lambda x:pd.notnull(x.pp_file)),"tpl_file"] = np.NaN
+        # mlt_df.loc[mlt_df.tpl_file.apply(lambda x:pd.notnull(x.pp_file)),"tpl_file"] = np.nan
         mlt_files = mlt_df.mlt_file.unique()
         # for suffix,tpl_file,layer,name in zip(self.mlt_df.suffix,
         #                                 self.mlt_df.tpl,self.mlt_df.layer,
@@ -2568,7 +2568,7 @@ class PstFromFlopyModel(object):
         info_df.loc[:, "model_ext_path"] = self.m.external_path
 
         # check that all files for a given package have the same number of entries
-        info_df.loc[:, "itmp"] = np.NaN
+        info_df.loc[:, "itmp"] = np.nan
         pak_dfs = {}
         for pak in info_df.pak.unique():
             df_pak = info_df.loc[info_df.pak == pak, :]
@@ -2762,9 +2762,9 @@ class PstFromFlopyModel(object):
         elif self.m.upw is not None:
             inact = self.m.upw.hdry
         if inact is None:
-            skip = lambda x: np.NaN if x == self.m.bas6.hnoflo else x
+            skip = lambda x: np.nan if x == self.m.bas6.hnoflo else x
         else:
-            skip = lambda x: np.NaN if x == self.m.bas6.hnoflo or x == inact else x
+            skip = lambda x: np.nan if x == self.m.bas6.hnoflo or x == inact else x
         print(self.hds_kperk)
         frun_line, df = setup_hds_obs(
             os.path.join(self.m.model_ws, hds_file),

--- a/pyemu/mat/mat_handler.py
+++ b/pyemu/mat/mat_handler.py
@@ -3575,7 +3575,7 @@ class Cov(Matrix):
             import matplotlib.pyplot as plt
             cov = pyemu.Cov.from_ascii("pest.post.cov")
             cc = cov.to_pearson()
-            cc.x[cc.x==1.0] = np.NaN
+            cc.x[cc.x==1.0] = np.nan
             plt.imshow(cc)
 
         """

--- a/pyemu/pst/pst_handler.py
+++ b/pyemu/pst/pst_handler.py
@@ -769,7 +769,7 @@ class Pst(object):
             extras = []
             for _ in range(nrows):
                 line = f.readline()
-                extra = np.NaN
+                extra = np.nan
                 if "#" in line:
                     raw = line.strip().split("#")
                     extra = " # ".join(raw[1:])
@@ -900,7 +900,7 @@ class Pst(object):
                     r = er[0].split()
                 else:
                     r = line.strip().split()
-                    extra.append(np.NaN)
+                    extra.append(np.nan)
 
                 raw.append(r[: len(defaults)])
 
@@ -911,7 +911,7 @@ class Pst(object):
 
         for col in fieldnames:
             if col not in df.columns:
-                df.loc[:, col] = np.NaN
+                df.loc[:, col] = np.nan
             if col in defaults:
                 df[col] = df.loc[:, col].fillna(defaults[col])
             if col in converters:
@@ -969,7 +969,7 @@ class Pst(object):
                     raw = er[0].split()
                     extra.append("#".join(er[1:]))
                 else:
-                    extra.append(np.NaN)
+                    extra.append(np.nan)
                     raw = line.split()
                 pilbl.append(raw[0].lower())
                 obgnme.append(raw[-1].lower())
@@ -3442,7 +3442,7 @@ class Pst(object):
 
         obs["stdev"] = obs.weight**-1
         obs["pe"] = 100.0 * (obs.stdev / obs.obsval.abs())
-        obs = obs.replace([np.inf, -np.inf], np.NaN)
+        obs = obs.replace([np.inf, -np.inf], np.nan)
 
         data = {c: [] for c in cols}
         for og, onames in obsgp.items():
@@ -3705,10 +3705,10 @@ class Pst(object):
         change_df.loc[:, "rel_upper"] = base_vals + rdelta
         change_df.loc[:, "rel_lower"] = base_vals - rdelta
 
-        change_df.loc[:, "chg_upper"] = np.NaN
+        change_df.loc[:, "chg_upper"] = np.nan
         change_df.loc[fpars, "chg_upper"] = change_df.fac_upper[fpars]
         change_df.loc[rpars, "chg_upper"] = change_df.rel_upper[rpars]
-        change_df.loc[:, "chg_lower"] = np.NaN
+        change_df.loc[:, "chg_lower"] = np.nan
         change_df.loc[fpars, "chg_lower"] = change_df.fac_lower[fpars]
         change_df.loc[rpars, "chg_lower"] = change_df.rel_lower[rpars]
 

--- a/pyemu/pst/pst_utils.py
+++ b/pyemu/pst/pst_utils.py
@@ -29,7 +29,7 @@ FFMT = lambda x: "{0:<20.10E} ".format(float(x))
 
 def str_con(item):
     if len(item) == 0:
-        return np.NaN
+        return np.nan
     return item.lower().strip()
 
 pst_config = {}
@@ -981,7 +981,7 @@ def get_phi_comps_from_recfile(recfile):
 
 
 def res_from_obseravtion_data(observation_data):
-    """create a PEST-style residual dataframe filled with np.NaN for
+    """create a PEST-style residual dataframe filled with np.nan for
     missing information
 
     Args:
@@ -1000,8 +1000,8 @@ def res_from_obseravtion_data(observation_data):
     res_df.loc[:, "name"] = res_df.pop("obsnme")
     res_df.loc[:, "measured"] = res_df.pop("obsval")
     res_df.loc[:, "group"] = res_df.pop("obgnme")
-    res_df.loc[:, "modelled"] = np.NaN
-    res_df.loc[:, "residual"] = np.NaN
+    res_df.loc[:, "modelled"] = np.nan
+    res_df.loc[:, "residual"] = np.nan
     return res_df
 
 

--- a/pyemu/utils/geostats.py
+++ b/pyemu/utils/geostats.py
@@ -346,8 +346,8 @@ class SpecSim2d(object):
         self.geostruct = geostruct
         self.delx = delx
         self.dely = dely
-        self.num_pts = np.NaN
-        self.sqrt_fftc = np.NaN
+        self.num_pts = np.nan
+        self.sqrt_fftc = np.nan
         self.effective_variograms = None
         self.initialize()
 
@@ -553,7 +553,7 @@ class SpecSim2d(object):
 
             gp_par = par.loc[gp_df.parnme, :]
             # use the parval1 as the mean
-            mean_arr = np.zeros((self.dely.shape[0], self.delx.shape[0])) + np.NaN
+            mean_arr = np.zeros((self.dely.shape[0], self.delx.shape[0])) + np.nan
             mean_arr[gp_df.i, gp_df.j] = gp_par.parval1
             # fill missing mean values
             mean_arr[np.isnan(mean_arr)] = gp_par.parval1.mean()
@@ -886,7 +886,7 @@ class OrdinaryKrige(object):
                 interpolating each grid node. Default is None
             minpts_interp (`int`): minimum number of `point_data` entires to use for interpolation at
                 a given grid node.  grid nodes with less than `minpts_interp`
-                `point_data` found will be skipped (assigned np.NaN).  Defaut is 1
+                `point_data` found will be skipped (assigned np.nan).  Defaut is 1
             maxpts_interp (`int`) maximum number of `point_data` entries to use for interpolation at
                 a given grid node.  A larger `maxpts_interp` will yield "smoother"
                 interplation, but using a large `maxpts_interp` will slow the
@@ -1003,8 +1003,8 @@ class OrdinaryKrige(object):
                 idx = np.arange(
                     len(zone_array.ravel())
                 )[(zone_array == pt_data_zone).ravel()]
-                # xzone[zone_array != pt_data_zone] = np.NaN
-                # yzone[zone_array != pt_data_zone] = np.NaN
+                # xzone[zone_array != pt_data_zone] = np.nan
+                # yzone[zone_array != pt_data_zone] = np.nan
 
                 df = self.calc_factors(
                     xzone,
@@ -1136,7 +1136,7 @@ class OrdinaryKrige(object):
             minpts_interp (`int`): minimum number of point_data entires to use for interpolation at
                 a given x,y interplation point.  interpolation points with less
                 than `minpts_interp` `point_data` found will be skipped
-                (assigned np.NaN).  Defaut is 1
+                (assigned np.nan).  Defaut is 1
             maxpts_interp (`int`): maximum number of point_data entries to use for interpolation at
                 a given x,y interpolation point.  A larger `maxpts_interp` will
                 yield "smoother" interplation, but using a large `maxpts_interp`
@@ -1265,7 +1265,7 @@ class OrdinaryKrige(object):
                 inames.append([])
                 idist.append([])
                 ifacts.append([])
-                err_var.append(np.NaN)
+                err_var.append(np.nan)
                 continue
             if verbose:
                 istart = datetime.now()
@@ -1349,7 +1349,7 @@ class OrdinaryKrige(object):
                     inames.append([])
                     idist.append([])
                     ifacts.append([])
-                    err_var.append(np.NaN)
+                    err_var.append(np.nan)
                     continue
                 else:
                     raise Exception("error solving for factors:{0}".format(str(e)))
@@ -1418,7 +1418,7 @@ class OrdinaryKrige(object):
         idist = [[]] * len(df.x)
         inames = [[]] * len(df.x)
         ifacts = [[]] * len(df.x)
-        err_var = [np.NaN] * len(df.x)
+        err_var = [np.nan] * len(df.x)
         with mp.Manager() as manager:
             point_pairs = manager.list(point_pairs)
             idist = manager.list(idist)
@@ -1511,7 +1511,7 @@ class OrdinaryKrige(object):
                 ifacts[idx] = [[]]
                 idist[idx] = [[]]
                 inames[idx] = [[]]
-                err_var[idx] = [np.NaN]
+                err_var[idx] = [np.nan]
                 continue
 
             # calc dist from this interp point to all point data...
@@ -2325,7 +2325,7 @@ def load_sgems_exp_var(filename):
             for item in attrib:
                 print(item, item.tag)
         df = pd.DataFrame({"x": x, "y": y, "pairs": pairs})
-        df.loc[df.y < 0.0, "y"] = np.NaN
+        df.loc[df.y < 0.0, "y"] = np.nan
         dfs[title] = df
     return dfs
 

--- a/pyemu/utils/gw_utils.py
+++ b/pyemu/utils/gw_utils.py
@@ -1004,7 +1004,7 @@ def setup_hds_obs(
             If skip can also be a np.ndarry with dimensions equal to the model.
             Observations are set up only for cells with Non-zero values in the array.
             If not np.ndarray or np.scalar(skip), then skip will be treated as a lambda function that
-            returns np.NaN if the value should be skipped.
+            returns np.nan if the value should be skipped.
         prefix (`str`): the prefix to use for the observation names. default is "hds".
         text (`str`): the text tag the flopy HeadFile instance.  Default is "head"
         precison (`str`): the precision string for the flopy HeadFile instance.  Default is "single"
@@ -1089,7 +1089,7 @@ def setup_hds_obs(
     if skip is not None:
         for col in data_cols:
             if np.isscalar(skip):
-                df.loc[df.loc[:, col] == skip, col] = np.NaN
+                df.loc[df.loc[:, col] == skip, col] = np.nan
             elif isinstance(skip, np.ndarray):
                 assert (
                     skip.ndim >= 2
@@ -1122,7 +1122,7 @@ def setup_hds_obs(
                         == 0
                     ),
                     col,
-                ] = np.NaN
+                ] = np.nan
             else:
                 df.loc[:, col] = df.loc[:, col].apply(skip)
 
@@ -1242,7 +1242,7 @@ def apply_hds_obs(hds_file, inact_abs_val=1.0e20, precision="single", text="head
     else:
         hds = flopy.utils.HeadFile(hds_file, precision=precision, text=text)
     kpers = df.kper.unique()
-    df.loc[:, "obsval"] = np.NaN
+    df.loc[:, "obsval"] = np.nan
     for kper in kpers:
         kstp = last_kstp_from_kper(hds, kper)
         data = hds.get_data(kstpkper=(kstp, kper))

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -2119,8 +2119,8 @@ def calc_array_par_summary_stats(arr_par_file="mult2model_info.csv"):
             elif len(zone_file) == 1:
                 zone_arr = np.loadtxt(zone_file[0])
             if zone_arr is not None:
-                arr[zone_arr == 0] = np.NaN
-                org_arr[zone_arr == 0] = np.NaN
+                arr[zone_arr == 0] = np.nan
+                org_arr[zone_arr == 0] = np.nan
 
         for stat, func in stat_dict.items():
             v = func(arr)

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -2244,29 +2244,6 @@ def _process_chunk_list_files(chunk, i, df):
     print("process", i, " processed ", len(chunk), "process_list_file calls")
 
 
-def _list_index_caster(x, add1):
-    vals = []
-    for xx in x:
-        if xx:
-            if any(s not in " 0123456789.-" for s in xx):
-                vals.append(xx.strip().strip("'\" "))
-            else:
-                if (xx.strip().isdigit() or
-                        (xx.strip()[0] == '-' and xx.strip()[1:].isdigit())):
-                    vals.append(add1 + int(xx))
-                else:
-                    try:
-                        vals.append(float(xx))
-                    except Exception as e:
-                        vals.append(xx.strip().strip("'\" "))
-
-    return tuple(vals)
-
-
-def _list_index_splitter_and_caster(x, add1):
-    return _list_index_caster(x.strip("()").replace('\'', '').split(","), add1)
-
-
 def _process_list_file(model_file, df):
     # print("processing model file:", model_file)
     df_mf = df.loc[df.model_file == model_file, :].copy()

--- a/pyemu/utils/pst_from.py
+++ b/pyemu/utils/pst_from.py
@@ -418,6 +418,7 @@ class PstFrom(object):
 
     def parse_kij_args(self, args, kwargs):
         """parse args into kij indices.  Called programmatically"""
+        args = list(args)
         if len(args) >= 2:
             ij_id = None
             if "ij_id" in kwargs:
@@ -2095,6 +2096,11 @@ class PstFrom(object):
                     "keys need to contain [`i` and `j`] or "
                     "[`x` and `y`]"
                 )
+        elif isinstance(index_cols, (list, tuple)):
+            if 'x' in index_cols and 'y' in index_cols:
+                xy_in_idx = [index_cols.index(c) for c in ['x', 'y']]
+            if 'i' in index_cols and 'j' in index_cols:
+                ij_in_idx = [index_cols.index(c) for c in ['i', 'j']]
 
         (
             index_cols,
@@ -3210,7 +3216,8 @@ def write_list_tpl(
             par_fill_value=fill_value,
             par_style=par_style,
         )
-        idxs = [[tuple(s) for s in df.loc[:, index_cols].values] for df in dfs]
+        # getting each input dataframe index col values, preserving individual column types
+        idxs = [list(zip(*[df[c] for c in index_cols])) for df in dfs]
         use_rows, nxs = _get_use_rows(
             df_tpl, idxs, use_rows, zero_based, tpl_filename, logger=logger
         )
@@ -3248,12 +3255,9 @@ def write_list_tpl(
                 else:
                     PyemuWarning(msg)
                 for col in use_cols:
-                    df_tpl["covgp{0}".format(col)] = df_tpl.loc[
-                        :, "covgp{0}".format(col)
-                    ].str.cat(
-                        pd.DataFrame(df_tpl.sidx.to_list()).iloc[:, 0].astype(str),
-                        "_cov",
-                    )
+                    df_tpl["covgp{0}".format(col)] = (df_tpl["covgp{0}".format(col)] +
+                                                      "_cov" +
+                                                      df_tpl[third_d[-1]].astype(str))
             else:
                 msg = (
                     "Coincidently located pars in list-style file. "
@@ -3365,18 +3369,19 @@ def _write_direct_df_tpl(
         This function is called by `PstFrom` programmatically
 
     """
+    from pyemu.utils.helpers import _try_pdcol_numeric
     # TODO much of this duplicates what is in _get_tpl_or_ins_df() -- could posssibly be consolidated
     # work out the union of indices across all dfs
 
-    sidx = []
-
-    didx = df.loc[:, index_cols].apply(tuple, axis=1)
-    sidx.extend(didx)
-
-    df_ti = pd.DataFrame({"sidx": sidx}, columns=["sidx"])
-    inames, fmt = _get_index_strfmt(index_cols)
-    df_ti = _get_index_strings(df_ti, fmt, zero_based)
-    df_ti = _getxy_from_idx(df_ti, get_xy, xy_in_idx, ij_in_idx)
+    df_ti = df[index_cols].copy()
+    # adjust int-like indicies to zero-base
+    df_ti = df_ti.apply(_try_pdcol_numeric,
+                        intadj=0 if zero_based else -1,
+                        downcast='integer')
+    # retaining sidx tuple definition as handy for use_rows selection
+    df_ti['sidx'] = list(zip(*[df_ti[c] for c in index_cols]))
+    df_ti = _get_index_strings(df_ti, index_cols)
+    df_ti = _getxy_from_idx(df_ti, index_cols, get_xy, xy_in_idx, ij_in_idx)
 
     df_ti, direct_tpl_df = _build_parnames(
         df_ti,
@@ -3393,7 +3398,7 @@ def _write_direct_df_tpl(
     )
     idxs = [tuple(s) for s in df.loc[:, index_cols].values]
     use_rows, nxs = _get_use_rows(
-        df_ti, [idxs], use_rows, zero_based, tpl_filename, logger=logger
+        df_ti,[idxs], use_rows, zero_based, tpl_filename, logger=logger
     )
     df_ti = df_ti.loc[use_rows]
     not_rows = ~direct_tpl_df.index.isin(use_rows)
@@ -3408,7 +3413,8 @@ def _write_direct_df_tpl(
     return df_ti, nxs
 
 
-def _get_use_rows(tpldf, idxcolvals, use_rows, zero_based, fnme, logger=None):
+def _get_use_rows(tpldf, idxcolvals, use_rows, zero_based, fnme,
+                  logger=None):
     """
     private function to get use_rows index within df based on passed use_rows
     option, which could be in various forms...
@@ -3484,41 +3490,30 @@ def _get_index_strfmt(index_cols):
         inames = ["idx{0}".format(i) for i in range(len(index_cols))]
     # full formatter string
     fmt = j.join([f"{iname}|{{{i}}}" for i, iname in enumerate(inames)])
-    # else:
-    #     # fmt = "{1:3}"
-    #     j = ""
-    #     if isinstance(index_cols[0], str):
-    #         inames = index_cols
-    #     else:
-    #         inames = ["{0}".format(i) for i in range(len(index_cols))]
-    #     # full formatter string
-    #     fmt = j.join([f"{{{i}:3}}" for i, iname in enumerate(inames)])
-    return inames, fmt
+    return fmt
 
 
-def _get_index_strings(df, fmt, zero_based):
-    if not zero_based:
-        # only if indices are ints (trying to support strings as par ids)
-        df.loc[:, "sidx"] = df.sidx.apply(
-            lambda x: tuple(xx - 1 if isinstance(xx, (int, np.integer)) else xx for xx in x)
-        )
-
-    df.loc[:, "idx_strs"] = df.sidx.apply(lambda x: fmt.format(*x)).str.replace(" ", "")
-    df.loc[:, "idx_strs"] = df.idx_strs.str.replace(":", "", regex=False).str.lower()
-    df.loc[:, "idx_strs"] = df.idx_strs.str.replace("|", ":", regex=False)
+def _get_index_strings(df, idxs):
+    fmt = _get_index_strfmt(idxs)
+    # avoiding pandas apply and .values to prevent casting of ints ot floats etc
+    df["idx_strs"] = [
+        fmt.format(*x
+                   ).replace(" ", ""
+                             ).replace(":", ""
+                                       ).replace("|", ":"
+                                                 ).lower()
+        for x in zip(*[df[c] for c in idxs])]
     return df
 
 
-def _getxy_from_idx(df, get_xy, xy_in_idx, ij_in_idx):
+def _getxy_from_idx(df, idxs, get_xy, xy_in_idx, ij_in_idx):
     if get_xy is None:
         return df
     if xy_in_idx is not None:
-        df[["x", "y"]] = pd.DataFrame(df.sidx.to_list()).iloc[:, xy_in_idx]
+        df[["x", "y"]] = df[idxs].iloc[:, xy_in_idx]
         return df
 
-    df.loc[:, "xy"] = df.sidx.apply(get_xy, ij_id=ij_in_idx)
-    df.loc[:, "x"] = df.xy.apply(lambda x: x[0])
-    df.loc[:, "y"] = df.xy.apply(lambda x: x[1])
+    df[['x', 'y']] = df[idxs].apply(get_xy, ij_id=ij_in_idx, axis=1).to_list()
     return df
 
 
@@ -3709,6 +3704,7 @@ def _get_tpl_or_ins_df(
         else: pandas.DataFrame with paranme and pargroup define for each `use_col`
 
     """
+    from pyemu.utils.helpers import _try_pdcol_numeric
     if isinstance(dfs, pd.DataFrame):
         dfs = [dfs]
     if not isinstance(dfs, list):
@@ -3716,17 +3712,17 @@ def _get_tpl_or_ins_df(
 
     # work out the union of indices across all dfs
     # order matters for obs
-    sidx = []
-    for df in dfs:
-        # avoiding df.values to prevent conversion to same type
-        didx = zip(*[df[col] for col in index_cols])
-        aidx = [i for i in didx if i not in sidx]
-        sidx.extend(aidx)
-
-    df_ti = pd.DataFrame({"sidx": sidx}, columns=["sidx"])
-    inames, fmt = _get_index_strfmt(index_cols)
-    df_ti = _get_index_strings(df_ti, fmt, zero_based)
-    df_ti = _getxy_from_idx(df_ti, get_xy, xy_in_idx, ij_in_idx)
+    idxs = [df[index_cols] for df in dfs]
+    df_ti = pd.concat(idxs).drop_duplicates()
+    # adjust int-like indicies to zero-base
+    df_ti = df_ti.apply(_try_pdcol_numeric,
+                        intadj=0 if zero_based else -1,
+                        downcast='integer')
+    df_ti['sidx'] = list(zip(*[df_ti[c] for c in index_cols]))
+    # df_ti = pd.DataFrame({"sidx": sidx}, columns=["sidx"])
+    # inames, fmt = _get_index_strfmt(index_cols)
+    df_ti = _get_index_strings(df_ti, index_cols)
+    df_ti = _getxy_from_idx(df_ti, index_cols, get_xy, xy_in_idx, ij_in_idx)
 
     if typ == "obs":
         return df_ti  #################### RETURN if OBS

--- a/pyemu/utils/pst_from.py
+++ b/pyemu/utils/pst_from.py
@@ -2194,7 +2194,7 @@ class PstFrom(object):
             in_filepst = in_fileabs.relative_to(self.new_d)
             tpl_filename = self.tpl_d / (mlt_filename + ".tpl")
         else:
-            mlt_filename = np.NaN
+            mlt_filename = np.nan
             # absolute path to org/datafile
             in_fileabs = self.original_file_d / filenames[0].name
             # pst input file (for tpl->in pair) is orgfile (in org dir)
@@ -3819,7 +3819,7 @@ def write_array_tpl(
                 if zval < 1:
                     continue
                 zone_org_arr = org_arr.copy()
-                zone_org_arr[zone_array != zval] = np.NaN
+                zone_org_arr[zone_array != zval] = np.nan
                 _check_diff(zone_org_arr, input_filename, zval)
     elif par_style == "m":
         org_arr = np.ones(shape)

--- a/pyemu/utils/pst_from.py
+++ b/pyemu/utils/pst_from.py
@@ -3497,7 +3497,7 @@ def _get_index_strfmt(index_cols):
 
 def _get_index_strings(df, idxs):
     fmt = _get_index_strfmt(idxs)
-    # avoiding pandas apply and .values to prevent casting of ints ot floats etc
+    # avoiding pandas apply and .values to prevent casting of ints to floats etc
     df["idx_strs"] = [
         fmt.format(*x
                    ).replace(" ", ""

--- a/pyemu/utils/pst_from.py
+++ b/pyemu/utils/pst_from.py
@@ -354,6 +354,8 @@ class PstFrom(object):
     def _dict_get_xy(self, arg, **kwargs):
         if isinstance(arg, list):
             arg = tuple(arg)
+        if len(arg) == 1:
+            arg = arg[0]
         xy = self._spatial_reference.get(arg, None)
         if xy is None:
             arg_len = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "numpy <2.0.0",
+    "numpy",
     "pandas",
 ]
 


### PR DESCRIPTION
- refactoring reading of list like files to support preserving index col type where it might be mixed -- and casting to int where needed.
- refactoring other pstfrom methods to preserve model file datatypes under numpy 2 -- removing reliance on sidx (which wasn't stored well in csv under numpy2) to align pars during the apply methods. Instead use index_col values directly. 
- updated tests
- np.NaN changed to np.nan
- Fixing pstfrom add_pars to make better used of x and y or i and j in index cols.
- Unpinning numpy