### PR TITLE
Fix for change with quotechar and delim flex in built in csvwriter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest] # , macos-latest] 
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
         run-type: [std]
         test-path: ["."]
         include:
           - os: macos-latest
-            python-version: 3.9
+            python-version: 3.11
 
     steps:
     - name: Checkout repo
@@ -76,7 +76,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Test Notebooks
-      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9 }}
+      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11 }}
       shell: bash -l {0}
       working-directory: ./examples
       run: |

--- a/autotest/utils_tests.py
+++ b/autotest/utils_tests.py
@@ -1745,9 +1745,9 @@ def hfb_zn_mult_test(tmp_path):
     hfb_pars = pd.read_csv(os.path.join(m.model_ws, 'hfb6_pars.csv'))
     hfb_tpl_contents = open(tpl_file, 'r').readlines()
     mult_str = ''.join(hfb_tpl_contents[1:]).replace(
-        '~  hbz_0000  ~', '0.1').replace(
-        '~  hbz_0001  ~', '1.0').replace(
-        '~  hbz_0002  ~', '10.0')
+        '~ hbz_0000 ~', '0.1').replace(
+        '~ hbz_0001 ~', '1.0').replace(
+        '~ hbz_0002 ~', '10.0')
     with open(hfb_pars.mlt_file.values[0], 'w') as mfp:
         mfp.write(mult_str)
     pyemu.gw_utils.apply_hfb_pars(os.path.join(m.model_ws, 'hfb6_pars.csv'))

--- a/pyemu/utils/gw_utils.py
+++ b/pyemu/utils/gw_utils.py
@@ -2749,10 +2749,8 @@ def write_hfb_zone_multipliers_template(m):
     with open(tpl_file, "w", newline="") as ofp:
         ofp.write("ptf ~\n")
         [ofp.write("{0}\n".format(line.strip())) for line in header]
-        ofp.flush()
-        hfb_in[["lay", "irow1", "icol1", "irow2", "icol2", "tpl"]].to_csv(
-            ofp, sep=" ", quotechar=" ", header=None, index=None, mode="a"
-        )
+        hfb_in[["lay", "irow1", "icol1", "irow2", "icol2", "tpl"]].apply(
+            lambda x: ofp.write(' '.join(x.astype(str)) + '\n'), axis=1)
 
     # make a lookup for lining up the necessary files to
     # perform multiplication with the helpers.apply_hfb_pars() function

--- a/pyemu/utils/os_utils.py
+++ b/pyemu/utils/os_utils.py
@@ -14,9 +14,9 @@ from ..pyemu_warnings import PyemuWarning
 
 ext = ""
 bin_path = os.path.join("..", "bin")
-if "linux" in platform.platform().lower():
+if "linux" in platform.system().lower():
     bin_path = os.path.join(bin_path, "linux")
-elif "darwin" in platform.platform().lower():
+elif "darwin" in platform.system().lower():
     bin_path = os.path.join(bin_path, "mac")
 else:
     bin_path = os.path.join(bin_path, "win")

--- a/pyemu/utils/pp_utils.py
+++ b/pyemu/utils/pp_utils.py
@@ -10,7 +10,6 @@ import warnings
 
 pd.options.display.max_colwidth = 100
 from pyemu.pst.pst_utils import SFMT, IFMT, FFMT, pst_config
-from pyemu.utils.helpers import run, _write_df_tpl
 from ..pyemu_warnings import PyemuWarning
 
 PP_FMT = {
@@ -616,16 +615,20 @@ def pilot_points_to_tpl(pp_file, tpl_file=None, name_prefix=None):
         pp_df.loc[:, "tpl"] = pp_df.parnme.apply(
             lambda x: "~    {0}    ~".format(x)
         )
-    _write_df_tpl(
-        tpl_file,
-        pp_df.loc[:, ["name", "x", "y", "zone", "tpl"]],
-        sep=" ",
-        index_label="index",
-        header=False,
-        index=False,
-        quotechar=" ",
-        quoting=2,
-    )
+    with open(tpl_file, "w") as f:
+        f.write("ptf ~\n")
+        pp_df.loc[:, ["name", "x", "y", "zone", "tpl"]].apply(
+            lambda x: f.write(' '.join(x.astype(str)) + '\n'), axis=1)
+    # _write_df_tpl(
+    #     tpl_file,
+    #     pp_df.loc[:, ["name", "x", "y", "zone", "tpl"]],
+    #     sep=" ",
+    #     index_label="index",
+    #     header=False,
+    #     index=False,
+    #     quotechar=" ",
+    #     quoting=2,
+    # )
 
     return pp_df
 


### PR DESCRIPTION
in python 3.13 the css writer now checks that quotechar and delim (and escapechar) are different. We were using quotechar as a space (`' '`) to avoid writing quotes in template files.

Reverting to using row-by-row native line write of ppl datasframes.