### PR TITLE
Update .gitattributes for GitHub language recognizition as Python

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,12 @@
-examples/* linguist-vendored=true
-autotest/* linguist-vendored=true
-dist/* linguist-vendored=true
-doc/* linguist-vendored=true
-build/* linguist-vendored=true
-misc/* linguist-vendored=true
-verification/* linguist-vendored=true
 pyemu/_version.py export-subst
+*.rei linguist-vendored # ignore because recognized as Reason
+*.ins linguist-vendored # ignore because recognized as LaTex
+*.aux linguist-vendored # ignore because recognized as LaTex
+*.tex linguist-vendored # ignore because recognized as LaTex
+*.go linguist-vendored # ignore because recognized as Go
+*.tpl linguist-vendored # ignore because recognized as Smarty
+*.bas linguist-vendored # ignore because recognized as VBA
+*.res linguist-vendored # ignore because recognized as ReScript
+*.dsp linguist-vendored # ignore because recognized as Faust
+*.spc linguist-vendored # ignore because recognized as PLSQL
+*.bat linguist-vendored # ignore because recognized as Batchfile


### PR DESCRIPTION
I saw that a lot of strange languages were detected by GitHub linguist because of the extensions of certain data files. This removes the languages that aren't on the repository such that python is the main language. This makes pyemu more easily findable on GitHub.

Current languages found:
![image](https://github.com/user-attachments/assets/24f35d8f-8820-450b-a44e-a93c13f35019)

With new .gitattributes file:
```
64.77%  Python
35.23%  Jupyter Notebook
```