### PR TITLE
Default behaviour change to write ensembles to dense format when ensemble size > 1e6

### DIFF
--- a/autotest/en_tests.py
+++ b/autotest/en_tests.py
@@ -671,6 +671,19 @@ def binary_test(tmp_path):
     e2 = datetime.now()
     print((e1 - s1).total_seconds())
     print((e2 - s2).total_seconds())
+    pe3 = pd.DataFrame(np.random.rand(10, int(1e7)))
+    pe3.columns = "parameter_number_" + pe3.columns.astype(str)
+    pe3 = pe3.rename(index={9:'base'})
+    pst = pyemu.Pst.from_par_obs_names(pe3.columns, obs_names)
+    pe3 = pyemu.ParameterEnsemble(pst=pst, df=pe3)
+    fname = pe3.to_binary("paren.jcb")
+    assert fname.endswith('bin')
+    pe4 = pyemu.ParameterEnsemble.from_binary(pst=pst, filename=fname)
+    assert pe4.shape == pe3.shape
+    d = (pe4._df - pe4._df).abs()
+    print(d.max().max())
+    assert d.max().max() < 1.0e-10
+    pass
 
 
 def mixed_par_draw_2_test():
@@ -763,9 +776,9 @@ if __name__ == "__main__":
     #fill_test()
     #factor_draw_test()
     #emp_cov_test()
-    emp_cov_draw_test()
+    # emp_cov_draw_test()
     #mixed_par_draw_2_test()
-    #binary_test()
+    binary_test()
     #get_phi_vector_noise_obs_test()
     #factor_draw_test()
     #enforce_test()


### PR DESCRIPTION
This PR changes default behaviour to write ensembles to dense binary format when the number of obs or parameters exceeds 1e6. 

This is consistent with changes coming in PEST++ and favours the dense binary format for more reliable and faster IO when the ensembles get big. 

USERS BEWARE: Will add a '.bin' extension to the requested filename if nobs or npars exceeds 1e6. Happy to discuss alternative options -- like error raising, or agnostically propagating filename but this seems the safest and leas disruptive. `Ensemble.to_binary()` should now return the written filename.