### PR TITLE
quick fix for issue where '\s+' is passed as mfile_sep

### DIFF
--- a/autotest/pst_from_tests.py
+++ b/autotest/pst_from_tests.py
@@ -974,6 +974,15 @@ def test_mf6_freyberg(tmp_path):
     #                   upper_bound=10, lower_bound=0.1)
 
     # add SP1 spatially constant, but temporally correlated wel flux pars
+    kper = 5
+    list_file = "freyberg6.wel_stress_period_data_{0}.txt".format(kper)
+    pf.add_parameters(filenames=list_file, par_type="grid",
+                      par_name_base="twel_mlt_{0}".format(kper),
+                      pargp="twel_mlt_{0}".format(kper), index_cols=[0, 1, 2],
+                      use_cols=[3], upper_bound=1.5, lower_bound=0.5,
+                      geostruct=gr_gs,
+                      mfile_sep=r'\s+')
+
     kper = 0
     list_file = "freyberg6.wel_stress_period_data_{0}.txt".format(kper+1)
     pf.add_parameters(filenames=list_file, par_type="constant",

--- a/pyemu/utils/pst_from.py
+++ b/pyemu/utils/pst_from.py
@@ -1048,6 +1048,8 @@ class PstFrom(object):
                         sep = " "
                         if rel_filepath.suffix.lower() == ".csv":
                             sep = ","
+                    elif sep == '\s+':
+                        sep = " " # sep for saving
                 if pd.api.types.is_integer_dtype(df.columns):  # df.columns.is_integer(): # really!???
                     hheader = False
                 else:


### PR DESCRIPTION
Flopy written external files are often written with a leading space in the first column. If these files have a .csv extension, adding to pars to PstFrom would require `mfile_sep=r"\s+"` to support consecutive delimiters. This was causing issues downstream when writing models at apply time (`r"\s+"` is not an accepted separator when writing!). For now scrubbing `"\s+"` to store `' '` in apply info file. 

Broader question -- should we be assuming `mfile_sep=" "` means `mfile_sep=r"\s+"` when passed (as we do if the model file extension is not .csv) or are we better honouring what the user explicitly passes here (if they are passing the keyword arg)? My preference is for the latter (as that is what we are currently doing, it provides more flexibility, explicit > implicit, and now mult white space can now be appropriately handled.)