### PR TITLE
small fixes to pyemu.helpers.prep_for_gpr(), gpr CI tests, and gpr hosaki notebook. 

### DIFF
--- a/autotest/utils_tests.py
+++ b/autotest/utils_tests.py
@@ -2812,7 +2812,7 @@ def gpr_compare_invest():
 
     pst_fname = os.path.join(m_d,case+".pst")
     gpr_t_d = os.path.join(case+"_gpr_template")
-    pyemu.helpers.prep_for_gpr(pst_fname,dv_pops,obs_pops,gpr_t_d=gpr_t_d,nverf=int(pop_size*.1),\
+    pyemu.helpers.prep_for_gpr(pst_fname,dv_pops,obs_pops,t_d=m_d,gpr_t_d=gpr_t_d,nverf=int(pop_size*.1),\
                                plot_fits=True,apply_standard_scalar=False,include_emulated_std_obs=True)
     gpst = pyemu.Pst(os.path.join(gpr_t_d,case+".pst"))
     shutil.copy2(os.path.join(m_d,case+".0.dv_pop.csv"),os.path.join(gpr_t_d,"initial_dv_pop.csv"))
@@ -2915,7 +2915,7 @@ def gpr_compare_invest():
         dv_pops.append(os.path.join(complex_m_d_iter,case+".0.dv_pop.csv"))
         obs_pops.append(os.path.join(complex_m_d_iter,case+".0.obs_pop.csv"))
         gpr_t_d_iter = gpr_t_d+"_outeriter{0}".format(iouter)
-        pyemu.helpers.prep_for_gpr(pst_fname,dv_pops,obs_pops,gpr_t_d=gpr_t_d_iter,nverf=int(pop_size*.1),
+        pyemu.helpers.prep_for_gpr(pst_fname,dv_pops,obs_pops,t_d=gpr_t_d,gpr_t_d=gpr_t_d_iter,nverf=int(pop_size*.1),
                                    plot_fits=True,apply_standard_scalar=False,include_emulated_std_obs=True)
         gpst_iter = pyemu.Pst(os.path.join(gpr_t_d_iter,case+".pst"))
         #aggdf = pd.read_csv(os.path.join(gpr_t_d,"gpr_aggregate_training_data.csv"),index_col=0)
@@ -2975,7 +2975,7 @@ def gpr_constr_invest():
 
     pst_fname = os.path.join(m_d, case + ".pst")
     gpr_t_d = os.path.join(case + "_gpr_template")
-    pyemu.helpers.prep_for_gpr(pst_fname, dv_pops, obs_pops, gpr_t_d=gpr_t_d, nverf=int(pop_size * .1), \
+    pyemu.helpers.prep_for_gpr(pst_fname, dv_pops, obs_pops,t_d=m_d, gpr_t_d=gpr_t_d, nverf=int(pop_size * .1), \
                                plot_fits=True, apply_standard_scalar=False, include_emulated_std_obs=True)
     gpst = pyemu.Pst(os.path.join(gpr_t_d, case + ".pst"))
     #shutil.copy2(os.path.join(m_d, case + ".0.dv_pop.csv"), os.path.join(gpr_t_d, "initial_dv_pop.csv"))
@@ -3090,7 +3090,7 @@ def gpr_constr_invest():
         dv_pops.append(os.path.join(complex_m_d_iter, case + ".0.dv_pop.csv"))
         obs_pops.append(os.path.join(complex_m_d_iter, case + ".0.obs_pop.csv"))
         gpr_t_d_iter = gpr_t_d + "_outeriter{0}".format(iouter)
-        pyemu.helpers.prep_for_gpr(pst_fname, dv_pops, obs_pops, gpr_t_d=gpr_t_d_iter, nverf=int(pop_size * .1),
+        pyemu.helpers.prep_for_gpr(pst_fname, dv_pops, obs_pops, t_d=gpr_t_d,gpr_t_d=gpr_t_d_iter, nverf=int(pop_size * .1),
                                    plot_fits=True, apply_standard_scalar=False, include_emulated_std_obs=True)
         gpst_iter = pyemu.Pst(os.path.join(gpr_t_d_iter, case + ".pst"))
         # aggdf = pd.read_csv(os.path.join(gpr_t_d,"gpr_aggregate_training_data.csv"),index_col=0)
@@ -3161,7 +3161,7 @@ def gpr_zdt1_test():
 
     pst_fname = os.path.join(m_d, case + ".pst")
     gpr_t_d = os.path.join(case + "_gpr_template")
-    pyemu.helpers.prep_for_gpr(pst_fname, dv_pops, obs_pops, gpr_t_d=gpr_t_d, nverf=int(pop_size * .1), \
+    pyemu.helpers.prep_for_gpr(pst_fname, dv_pops, obs_pops, t_d=m_d,gpr_t_d=gpr_t_d, nverf=int(pop_size * .1), \
                                plot_fits=True, apply_standard_scalar=False, include_emulated_std_obs=True)
     gpst = pyemu.Pst(os.path.join(gpr_t_d, case + ".pst"))
     shutil.copy2(os.path.join(m_d, case + ".0.dv_pop.csv"), os.path.join(gpr_t_d, "initial_dv_pop.csv"))
@@ -3258,7 +3258,7 @@ def gpr_zdt1_ppw():
 
 if __name__ == "__main__":
     #ppu_geostats_test(".")
-    #gpr_compare_invest()
+    gpr_compare_invest()
     #gpr_constr_test()
     # import sys
     # t_d = "constr_ppw_template"
@@ -3267,7 +3267,7 @@ if __name__ == "__main__":
     # from forward_run import helper as frun
     # ppw_worker(0,case,t_d,"localhost",4004,frun)
     #pypestworker_test()
-    gpr_constr_test()
+    # gpr_constr_test()
     #gpr_zdt1_test()
     #ac_draw_test(".")
     #while True:

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -24,3 +24,6 @@ dependencies:
   - scikit-learn
   - pip
   - ffmpeg
+  - jupyter
+  - jupytext
+  - jupyterlab

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -4181,7 +4181,7 @@ def prep_for_gpr(pst_fname,input_fnames,output_fnames,gpr_t_d="gpr_template",t_d
         import matplotlib.pyplot as plt
         from matplotlib.backends.backend_pdf import PdfPages
         pdf = PdfPages(os.path.join(gpr_t_d,"gpr_fits.pdf"))
-    for output_name in output_names:
+    for i,output_name in enumerate(output_names):
 
         y_verf = df.loc[:,output_name].values.copy()[cut:]
         y_train = df.loc[:, output_name].values.copy()[:cut]
@@ -4221,8 +4221,8 @@ def prep_for_gpr(pst_fname,input_fnames,output_fnames,gpr_t_d="gpr_template",t_d
                 plt.close(fig)
 
 
-
-        model_fname = os.path.split(pst_fname)[1].split('.')[0]+"."+output_name.split(':')[1].split('.')[0]+".pkl"
+        objname = f'obj_{i}'
+        model_fname = os.path.split(pst_fname)[1]+"."+objname+".pkl"
         if os.path.exists(os.path.join(gpr_t_d,model_fname)):
             print("WARNING: model_fname '{0}' exists, overwriting...".format(model_fname))
         with open(os.path.join(gpr_t_d,model_fname),'wb') as f:

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -4325,10 +4325,11 @@ def prep_for_gpr(pst_fname,input_fnames,output_fnames,gpr_t_d="gpr_template",t_d
     gpst.write(os.path.join(gpr_t_d,gpst_fname),version=2)
     print("saved gpr pst:",gpst_fname,"in gpr_t_d",gpr_t_d)
 
-    #if it exists, copy pestpp mou bin from t_d over to gpr_t_d. otherwise, we assume bin is in path
-    mou_bin = [f for f in os.listdir(t_d) if 'pestpp-mou' in f]
-    if len(mou_bin)>0:
-        shutil.copy2(os.path.join(t_d,mou_bin[0]),os.path.join(gpr_t_d,mou_bin))
+    #if they exist, copy pestpp bins from t_d over to gpr_t_d. otherwise, we assume bin is in path
+    pp_bins = [f for f in os.listdir(t_d) if 'pestpp-' in f]
+    if len(pp_bins)>0:
+        for pp_bin in pp_bins:
+            shutil.copy2(os.path.join(t_d,pp_bin),os.path.join(gpr_t_d,pp_bin))
 
     try:
         pyemu.os_utils.run("pestpp-mou {0}".format(gpst_fname),cwd=gpr_t_d)

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -4221,7 +4221,7 @@ def prep_for_gpr(pst_fname,input_fnames,output_fnames,gpr_t_d="gpr_template",gp_
 
 
 
-        model_fname = os.path.split(pst_fname)[1]+"."+output_name+".pkl"
+        model_fname = os.path.split(pst_fname)[1].split('.')[0]+"."+output_name.split(':')[1].split('.')[0]+".pkl" #shortened to not exceed windoze path char limit
         if os.path.exists(os.path.join(gpr_t_d,model_fname)):
             print("WARNING: model_fname '{0}' exists, overwriting...".format(model_fname))
         with open(os.path.join(gpr_t_d,model_fname),'wb') as f:


### PR DESCRIPTION
prep_for_gpr now saves out a generic obj name to pickle files to avoid char length limits and has an added feature to copy over the pestpp bins from the template dir, because prep_for_gpr() was building a fresh template with no binaries in it and failing the noptmax 0 test. updated gpr tests and hosaki NB to include new t_d arg, added option in hosaki NB to grab the pestpp bins if not in path