### PR TITLE
Pinning openblass to pre 0.3.30.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
       shell: bash -l {0}
       working-directory: ./autotest
       run: |
-        pytest -rP -rx --capture=no -v -n=auto --tb=native --cov=pyemu --cov-report=lcov ${{ matrix.test-path }}
+        pytest -rP -rx --capture=no -v -n=auto --tb=native --durations=20 --cov=pyemu --cov-report=lcov ${{ matrix.test-path }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -3,7 +3,8 @@ channels:
   - conda-forge
 dependencies:
   # required
-  - python>=3.8
+  - python>=3.9
+  - libopenblas < 0.3.30
   - numpy
   - pandas
   # optional

--- a/pyemu/utils/pst_from.py
+++ b/pyemu/utils/pst_from.py
@@ -1048,7 +1048,7 @@ class PstFrom(object):
                         sep = " "
                         if rel_filepath.suffix.lower() == ".csv":
                             sep = ","
-                    elif sep == '\s+':
+                    elif sep == r'\s+':
                         sep = " " # sep for saving
                 if pd.api.types.is_integer_dtype(df.columns):  # df.columns.is_integer(): # really!???
                     hheader = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Hydrology",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "numpy",
     "pandas",


### PR DESCRIPTION
To circumvent issues in numpy linalg steps on linux that was causing CI to hang. 
!!!This might need more attention!!!

## issue
Timeouts on linux seem to be caused by hanging in:
```
File "/home/runner/work/pyemu/pyemu/autotest/pst_from_tests.py", line 1174, in test_mf6_freyberg
  cov = pf.build_prior(fmt="none").to_dataframe()
File "/home/runner/work/pyemu/pyemu/pyemu/utils/pst_from.py", line 617, in build_prior
  cov = pyemu.helpers.geostatistical_prior_builder(
File "/home/runner/work/pyemu/pyemu/pyemu/utils/helpers.py", line 723, in geostatistical_prior_builder
  ci = cov.inv
File "/home/runner/work/pyemu/pyemu/pyemu/mat/mat_handler.py", line 1196, in inv
  x=np.linalg.inv(self.__x),
File "/home/runner/micromamba/envs/pyemu/lib/python3.9/site-packages/numpy/linalg/_linalg.py", line 608, in inv
  ainv = _umath_linalg.inv(a, signature=signature)
```

With the only meaningful change to the running environment:
```
-  libopenblas                           0.3.30          pthreads_h94d23a6_0    conda-forge. <-----failing
+  libopenblas                           0.3.29          pthreads_h94d23a6_0    conda-forge. <----passing
```