### PR TITLE
phi components to include prior info if pestmode is "reg"

### DIFF
--- a/pyemu/pst/pst_handler.py
+++ b/pyemu/pst/pst_handler.py
@@ -326,7 +326,7 @@ class Pst(object):
         ogroups = self.observation_data.groupby("obgnme").groups
         self.res.index = self.res.name
         obs = self.observation_data[['obsval','weight']]
-        if (not self.control_data.pestmode.startswith("reg")
+        if (self.control_data.pestmode.startswith("reg")
             and self.prior_information.shape[0] > 0):
             pi_ogroups = self.prior_information.groupby("obgnme").groups
             pi_df = self.prior_information


### PR DESCRIPTION
I think we wan't to include prior information if in reg mode right? 