### PR TITLE
Change the default behavior of the _try_copy_dir function in os_utils regarding symlinks

### DIFF
--- a/pyemu/utils/os_utils.py
+++ b/pyemu/utils/os_utils.py
@@ -249,11 +249,11 @@ def _try_remove_existing(d, forgive=False):
 
 def _try_copy_dir(o_d, n_d):
     try:
-        shutil.copytree(o_d, n_d)
+        shutil.copytree(o_d, n_d, symlinks=True)
     except PermissionError:
         time.sleep(3) # pause for windows locking issues
         try:
-            shutil.copytree(o_d, n_d)
+            shutil.copytree(o_d, n_d, symlinks=True)
         except Exception as e:
             raise Exception(
                 f"unable to copy files from base dir: "


### PR DESCRIPTION
Added a symlinks=True argument to the shutil.copytree call in _try_copy_dir within the os_utils module.
This sets the default behavior to copy symbolic links as symbolic links, instead of copying the files they point to.

I'm not sure if there's a use case for the current behavior, where the contents of a symlinked directory are copied into the new directory.
If someone sees a valid reason to keep that behavior, feel free to reject this PR.

Thank you in advance!

P.S.: Some tests failed, possibly due to an improperly set up environment on my side.
<img width="1527" height="850" alt="Capture d’écran 2025-10-22 143931" src="https://github.com/user-attachments/assets/0bc9625d-d6bb-4866-96db-8d8fc058617c" />

