### PR TITLE
Declare `scikit-learn` as an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ optional = [
     "jinja2",  # for to_latex options
     "pypestutils",
     "scikit-learn",
+    "graphviz",
 ]
 test = [
     "coveralls",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ optional = [
     "scipy",
     "shapely",
     "jinja2",  # for to_latex options
-    "pypestutils"
+    "pypestutils",
+    "scikit-learn",
 ]
 test = [
     "coveralls",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ optional = [
     "jinja2",  # for to_latex options
     "pypestutils",
     "scikit-learn",
-    "graphviz",
 ]
 test = [
     "coveralls",


### PR DESCRIPTION
`scikit-learn` is used in the `pyemu.emulators` module, among other places:

https://github.com/pypest/pyemu/blob/5dd3c785991ec991974c53cd0b1058281a2f872f/pyemu/emulators/__init__.py#L47-L55

`graphviz` is just used in `misc\graph_pyemu.py`.