### PR TITLE
Add `runner/` pytest temp dir to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ autotest/*.dat
 autotest/temp
 autotest/.noseids
 autotest/temp*
+runner/
 
 examples/.ipynb*
 


### PR DESCRIPTION
I think this makes sense - otherwise when running with `pytest --basetemp=runner autotest` as per the README, the `runner` dir is tracked by git.