### PR TITLE
Declare `pytest-timeout` as a test dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ test = [
     "pytest",
     "pytest-cov",
     "pytest-xdist",
+    "pytest-timeout",
     "flaky",
     "nbmake",
     "modflow-devtools",


### PR DESCRIPTION
It's being used here, for example:

https://github.com/pypest/pyemu/blob/5dd3c785991ec991974c53cd0b1058281a2f872f/autotest/utils_tests.py#L826-L827

At the moment, this isn't declared as a dependency so when trying to collect the pytest tests, a warning is emitted:

```
>> pytest autotest --collect-only 

...

autotest\utils_tests.py:826
  C:\Users\namc\Repositories\pyemu\autotest\utils_tests.py:826: PytestUnknownMarkWarning: Unknown pytest.mark.timeout - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
```