### PR TITLE
Improve developer experience for running binaries from test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ pyemu/.idea
 
 autotest/*.bin
 autotest/*.dat
+autotest/pypestworker_*.txt
 autotest/temp
 autotest/.noseids
 autotest/temp*

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Python dependencies for the test suite can be installed via `pip install -e .[op
 * [PEST++](https://github.com/usgs/pestpp/releases), e.g. `pestpp-ies`, `pestpp-mou`, etc.
 * [MODFLOW](https://github.com/MODFLOW-ORG/executables), i.e. `mf6`
 * [MODFLOW-NWT](https://www.usgs.gov/software/modflow-nwt-a-newton-formulation-modflow-2005), i.e. `mfnwt`. Note that the pre-built Windows binaries are named `MODFLOW-NWT.exe` and `MODFLOW-NWT_64.exe` - usually on Windows you would want the 64-bit version, and to rename it to `mfnwt.exe` for compatibility with the pyEMU test suite.
+* [MODFLOW-USG](https://www.usgs.gov/software/modflow-usg-unstructured-grid-version-modflow-simulating-groundwater-flow-and-tightly), i.e. `mfusg_gsi`.
 
 These should be placed in the relevant `./bin/win`, `./bin/linux`, or `./bin/mac` directories (depending on your OS).
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Some notes that might be helpful for building your PR and testing:
 * As tests are run in parallel, where tests require read/write access to files it is safest to sandbox runs. 
 Pytest has a built-in fixture `tmp_path` that can help with this. 
 Setting optional argument `--basetemp` can be helpful for accessing the locally run files. 
-## Running test locally
+## Running tests locally
 To be able to make clean use of pytests fixture decorators etc., 
 it is recommended to run local tests through `pytest` (rather than use from script execution and commenting in 
 __main__ block). For e.g.:
@@ -126,6 +126,10 @@ with pytest-xdist, local runs can be parallelized:
 
 ### Run a specific test [`this_test()`]:
 > pytest --basetemp=runner autotest/testfile_tests.py::this_test
+
+### Test dependencies
+
+Python dependencies for the test suite can be installed via `pip install -e .[optional, test]` (they are recorded in [`./pyproject.toml`](./pyproject.toml)). You should also include [binaries for PEST++](https://github.com/usgs/pestpp/releases) in the relevant `./bin/win`, `./bin/linux`, or `./bin/mac` directories depending on your OS.
 
 ### Using an IDE:
 Most modern, feature-rich editors and IDEs support launching pytest within debug or run consoles. 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ with pytest-xdist, local runs can be parallelized:
 
 ### Test dependencies
 
-Python dependencies for the test suite can be installed via `pip install -e .[optional, test]` (they are recorded in [`./pyproject.toml`](./pyproject.toml)). You should also include [binaries for PEST++](https://github.com/usgs/pestpp/releases) in the relevant `./bin/win`, `./bin/linux`, or `./bin/mac` directories depending on your OS.
+Python dependencies for the test suite can be installed via `pip install -e .[optional, test]` (they are recorded in [`./pyproject.toml`](./pyproject.toml)). You should also include [binaries for PEST++](https://github.com/usgs/pestpp/releases) and [binaries for MODFLOW](https://github.com/MODFLOW-ORG/executables) in the relevant `./bin/win`, `./bin/linux`, or `./bin/mac` directories (depending on your OS).
 
 ### Using an IDE:
 Most modern, feature-rich editors and IDEs support launching pytest within debug or run consoles. 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,13 @@ with pytest-xdist, local runs can be parallelized:
 
 ### Test dependencies
 
-Python dependencies for the test suite can be installed via `pip install -e .[optional, test]` (they are recorded in [`./pyproject.toml`](./pyproject.toml)). You should also include [binaries for PEST++](https://github.com/usgs/pestpp/releases) and [binaries for MODFLOW](https://github.com/MODFLOW-ORG/executables) in the relevant `./bin/win`, `./bin/linux`, or `./bin/mac` directories (depending on your OS).
+Python dependencies for the test suite can be installed via `pip install -e .[optional, test]` (they are recorded in [`./pyproject.toml`](./pyproject.toml)). You should also include binaries for various integrations:
+
+* [PEST++](https://github.com/usgs/pestpp/releases), e.g. `pestpp-ies`, `pestpp-mou`, etc.
+* [MODFLOW](https://github.com/MODFLOW-ORG/executables), i.e. `mf6`
+* [MODFLOW-NWT](https://www.usgs.gov/software/modflow-nwt-a-newton-formulation-modflow-2005), i.e. `mfnwt`. Note that the pre-built Windows binaries are named `MODFLOW-NWT.exe` and `MODFLOW-NWT_64.exe` - usually on Windows you would want the 64-bit version, and to rename it to `mfnwt.exe` for compatibility with the pyEMU test suite.
+
+These should be placed in the relevant `./bin/win`, `./bin/linux`, or `./bin/mac` directories (depending on your OS).
 
 ### Using an IDE:
 Most modern, feature-rich editors and IDEs support launching pytest within debug or run consoles. 

--- a/README.md
+++ b/README.md
@@ -132,9 +132,7 @@ with pytest-xdist, local runs can be parallelized:
 Python dependencies for the test suite can be installed via `pip install -e .[optional, test]` (they are recorded in [`./pyproject.toml`](./pyproject.toml)). You should also include binaries for various integrations:
 
 * [PEST++](https://github.com/usgs/pestpp/releases), e.g. `pestpp-ies`, `pestpp-mou`, etc. These can be automatically installed via the `get-pestpp` script included with pyEMU (see above).
-* [MODFLOW](https://github.com/MODFLOW-ORG/executables), i.e. `mf6`
-* [MODFLOW-NWT](https://www.usgs.gov/software/modflow-nwt-a-newton-formulation-modflow-2005), i.e. `mfnwt`. Note that the pre-built Windows binaries are named `MODFLOW-NWT.exe` and `MODFLOW-NWT_64.exe` - usually on Windows you would want the 64-bit version, and to rename it to `mfnwt.exe` for compatibility with the pyEMU test suite.
-* [MODFLOW-USG](https://www.usgs.gov/software/modflow-usg-unstructured-grid-version-modflow-simulating-groundwater-flow-and-tightly), i.e. `mfusg_gsi`.
+* [MODFLOW exectuables](https://github.com/MODFLOW-ORG/executables), i.e. `mf6`, `mfnwt`, `mfusg_gsi`. These can be automatically installed using flopy's [`get-modflow`](https://flopy.readthedocs.io/en/latest/md/get_modflow.html) command. 
 
 These should be placed in the relevant `./bin/win`, `./bin/linux`, or `./bin/mac` directories (depending on your OS).
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ with pytest-xdist, local runs can be parallelized:
 
 Python dependencies for the test suite can be installed via `pip install -e .[optional, test]` (they are recorded in [`./pyproject.toml`](./pyproject.toml)). You should also include binaries for various integrations:
 
-* [PEST++](https://github.com/usgs/pestpp/releases), e.g. `pestpp-ies`, `pestpp-mou`, etc.
+* [PEST++](https://github.com/usgs/pestpp/releases), e.g. `pestpp-ies`, `pestpp-mou`, etc. These can be automatically installed via the `get-pestpp` script included with pyEMU (see above).
 * [MODFLOW](https://github.com/MODFLOW-ORG/executables), i.e. `mf6`
 * [MODFLOW-NWT](https://www.usgs.gov/software/modflow-nwt-a-newton-formulation-modflow-2005), i.e. `mfnwt`. Note that the pre-built Windows binaries are named `MODFLOW-NWT.exe` and `MODFLOW-NWT_64.exe` - usually on Windows you would want the 64-bit version, and to rename it to `mfnwt.exe` for compatibility with the pyEMU test suite.
 * [MODFLOW-USG](https://www.usgs.gov/software/modflow-usg-unstructured-grid-version-modflow-simulating-groundwater-flow-and-tightly), i.e. `mfusg_gsi`.


### PR DESCRIPTION
I've added a bit of documentation about test dependencies to the README, and added a `.gitignore` entry for pypestworker log files that get generated.

Although perhaps, rather than adding `autotest/pypestworker_*.txt` to `.gitignore`, it would be better to reconfigure the workers to write the log files to `autotest/temp` - happy to take advice on that.

I tried building `MODFLOW-USG` from source without much luck - so I tried `git checkout 96b16ef1544277a5cf64642b3aa5b5d2f89c4009 -- bin/win/mfusg.exe` to get an old binary and renamed it to `mfusg_gsi.exe` ... happily it worked and I was able to pass `autotest\pst_from_tests.py::usg_freyberg_test` :)
It would be good if you could provide advice on this to improve/correct the information I've got in the README for this one.

Finally, there's a mention of `mt3dusgs` here:
https://github.com/pypest/pyemu/blob/5dd3c785991ec991974c53cd0b1058281a2f872f/autotest/conftest.py#L63-L72

But I can't find `mt3dusgs` referenced anywhere else - maybe it can be removed?
