### PR TITLE
Replace `np.core.records.fromarrays` with `np.rec.fromarrays`

### DIFF
--- a/pyemu/mat/mat_handler.py
+++ b/pyemu/mat/mat_handler.py
@@ -37,7 +37,7 @@ def save_coo(x, row_names, col_names, filename, chunk=None):
     header = np.array((x.shape[1], x.shape[0], x.nnz), dtype=Matrix.binary_header_dt)
     header.tofile(f)
 
-    data = np.core.records.fromarrays([x.row, x.col, x.data], dtype=Matrix.coo_rec_dt)
+    data = np.rec.fromarrays([x.row, x.col, x.data], dtype=Matrix.coo_rec_dt)
     data.tofile(f)
 
     for name in col_names:
@@ -1897,7 +1897,7 @@ class Matrix(object):
 
         if chunk is None:
             flat = self.x[row_idxs, col_idxs].flatten()
-            data = np.core.records.fromarrays(
+            data = np.rec.fromarrays(
                 [row_idxs, col_idxs, flat], dtype=self.coo_rec_dt
             )
             data.tofile(f)
@@ -1908,7 +1908,7 @@ class Matrix(object):
                 # print(row_idxs[start],row_idxs[end])
                 # print("chunk",start,end)
                 flat = self.x[row_idxs[start:end], col_idxs[start:end]].flatten()
-                data = np.core.records.fromarrays(
+                data = np.rec.fromarrays(
                     [row_idxs[start:end], col_idxs[start:end], flat],
                     dtype=self.coo_rec_dt,
                 )
@@ -2052,7 +2052,7 @@ class Matrix(object):
 
         if chunk is None:
             flat = self.x[row_idxs, col_idxs].flatten()
-            data = np.core.records.fromarrays([icount, flat], dtype=self.binary_rec_dt)
+            data = np.rec.fromarrays([icount, flat], dtype=self.binary_rec_dt)
             # write
             data.tofile(f)
         else:
@@ -2060,7 +2060,7 @@ class Matrix(object):
             while True:
                 # print(row_idxs[start],row_idxs[end])
                 flat = self.x[row_idxs[start:end], col_idxs[start:end]].flatten()
-                data = np.core.records.fromarrays(
+                data = np.rec.fromarrays(
                     [icount[start:end], flat], dtype=self.binary_rec_dt
                 )
                 data.tofile(f)


### PR DESCRIPTION
Replace `np.core.records.fromarrays` with `np.rec.fromarrays` in `pyemu/mat/mat_handler.py`.

The `np.core` module is deprecated and emits a warning (e.g. when running the test suite).

```
pyemu\mat\mat_handler.py:2055: DeprecationWarning: numpy.core is deprecated and has been renamed to numpy._core. The numpy._core namespace contains private NumPy internals and its use is discouraged, as NumPy internals can change without warning in any release. In practice, most real-world usage of numpy.core is to access functionality in the public NumPy API. If that is the case, use the public NumPy API. If not, you are using NumPy internals. If you would still like to access an internal attribute, use numpy._core.records.
```