### PR TITLE
Use a non-interactive `matplotlib` backend for the test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,6 @@ jobs:
         --cov=pyemu --cov-report=lcov \
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        MPLBACKEND: Agg  # non-interactive backend for matplotlib
 
     - name: Test Notebooks
       if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == 3.12 }}

--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -81,7 +81,7 @@ def _ch2testdir(monkeypatch):
     monkeypatch.chdir(testdir)
 
 @pytest.fixture(autouse=True)
-def _turn_off_show():
+def _use_plt_agg_backend():
     try:
         import matplotlib.pyplot as plt
     except ImportError:

--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -79,3 +79,12 @@ def full_exe_ref_dict():
 def _ch2testdir(monkeypatch):
     testdir = Path(__file__).parent
     monkeypatch.chdir(testdir)
+
+@pytest.fixture(autouse=True)
+def _turn_off_show():
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        pass
+    else:
+        plt.switch_backend("Agg")


### PR DESCRIPTION
I tried running the `autotest\plot_tests.py::pst_plot_test` test locally, but I got Tkinter errors.

<details>
In my experience, this is quite common under pytest.

The details are a bit murky to me, but my understanding is that Tkinter is a Python wrapper around Tcl/Tk, which consists of the C libraries and a set of [Tcl](https://www.tcl-lang.org/) scripts. Internally, Python uses environment variables like TCL_LIBRARY and TK_LIBRARY to find these scripts, but it can be a fragile affair when there are virtual environments involved, pytest etc.

The default GitHub Windows runners use Python builds which tend to have this issue.
https://github.com/orgs/community/discussions/26434
</details>

By default, `matplotlib` uses Tkinter as an interactive backend, but you can set it to use Agg instead, which is non-interactive (and faster). Interactivity (e.g. the ability to zoom in etc.) isn't really necessary in a test environment, since usually you usually don't even look at the plots anyway.

The CI config already uses it:

https://github.com/pypest/pyemu/blob/5dd3c785991ec991974c53cd0b1058281a2f872f/.github/workflows/ci.yml#L135

So this change just brings uniformity for local tests too.