### PR TITLE
Update description of current distributions included from `usgs/pestpp`

### DIFF
--- a/get_pestpp.md
+++ b/get_pestpp.md
@@ -73,7 +73,7 @@ Other auto-select options are only available if the current user can write files
 
 ## Selecting a distribution
 
-By default the distribution from the [`usgs/pestpp` repository](https://github.com/usgs/pestpp) is installed. This includes the MODFLOW 6 binary `mf6` and over 20 other related programs. The utility can also install from forks of the main [PEST++ 6 repo](https://github.com/usgs/pestpp) or other repo distributions, which contain only:
+By default the distribution from the [`usgs/pestpp` repository](https://github.com/usgs/pestpp) is installed. The utility can also install from forks of the main [PEST++ 6 repo](https://github.com/usgs/pestpp) or other repo distributions. These repos include the following executables:
 
 - `pestpp-da`
 - `pestpp-glm`


### PR DESCRIPTION
When using `pestpp`, the default behaviour doesn't seem to include any executables except those from `pestpp`, e.g. it doesn't include `mf6`. I'm guessing that these executables are no longer distributed in the releases in the upstream `usgs/pestpp` repo, and that these docs are just a bit out of date - so trying to update them.

My guess might be wrong - if there's a way to download other relevant executables using `get-pestpp` it would be helpful to incorporate into #653 