### PR TITLE
Don't trigger CI for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,14 @@ on:
   schedule:
     - cron: '0 8 * * *' # run at 8 AM UTC (12 AM PST, 8 PM NZST)
   push:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
   workflow_dispatch:
-
 jobs:
   pyemuCI:
     name: autotests


### PR DESCRIPTION
Running CI is unnecessary if only files in the `./docs` directory and/or markdown files are modified.

I use this sort of config [on another project](https://github.com/usethis-python/usethis-python/blob/1def16b7585644fa5130851698ee9b7b1f545594/.github/workflows/ci.yml#L7-L15), so it's "tested" from that perspective.


