### PR TITLE
Use lazy-loading for `flopy` and `matplotlib`

### DIFF
--- a/pyemu/emulators/__init__.py
+++ b/pyemu/emulators/__init__.py
@@ -7,6 +7,7 @@ from .transformers import (
     TransformerPipeline,
     AutobotsAssemble
 )
+import importlib.util
 from .base import Emulator
 from .dsi import DSI
 #from .lpfa import LPFA
@@ -28,11 +29,7 @@ __all__ = [
 ]
 
 # Check sklearn availability
-try:
-    import sklearn
-    HAS_SKLEARN = True
-except ImportError:
-    HAS_SKLEARN = False
+HAS_SKLEARN = importlib.util.find_spec("sklearn") is not None
 
 # Conditional imports
 if HAS_SKLEARN:

--- a/pyemu/emulators/lpfa.py
+++ b/pyemu/emulators/lpfa.py
@@ -3,15 +3,16 @@ Learning-based pattern-data-driven forecast approach (LPFA) emulator implementat
 
 """
 from __future__ import print_function, division
+import importlib.util
 
 # Check sklearn availability at module level
-try:
+HAS_SKLEARN = importlib.util.find_spec("sklearn") is not None
+
+if HAS_SKLEARN:
     from sklearn.model_selection import train_test_split
     from sklearn.decomposition import PCA
     from sklearn.neural_network import MLPRegressor
-    HAS_SKLEARN = True
-except ImportError:
-    HAS_SKLEARN = False
+else:
     # Create dummy classes or set to None
     train_test_split = None
     PCA = None

--- a/pyemu/emulators/transformers.py
+++ b/pyemu/emulators/transformers.py
@@ -4,14 +4,14 @@ Transformer classes for data transformations in emulators.
 from __future__ import print_function, division
 import numpy as np
 import pandas as pd
-
+import importlib.util
 
 # Check sklearn availability at module level
-try:
+HAS_SKLEARN = importlib.util.find_spec("sklearn") is not None
+
+if HAS_SKLEARN:
     from sklearn.preprocessing import StandardScaler
-    HAS_SKLEARN = True
-except ImportError:
-    HAS_SKLEARN = False
+else:
     # Create dummy classes or set to None
     StandardScaler = None
 

--- a/pyemu/legacy/pstfromflopy.py
+++ b/pyemu/legacy/pstfromflopy.py
@@ -1,9 +1,9 @@
 import copy
+import importlib.util
 import os
 import shutil
 import warnings
 
-import flopy
 import numpy as np
 import pandas as pd
 
@@ -17,6 +17,7 @@ from pyemu.utils import (
 )
 from pyemu.utils.helpers import _write_df_tpl
 
+HAS_FLOPY= importlib.util.find_spec("matplotlib") is not None
 
 wildass_guess_par_bounds_dict = {
     "hk": [0.01, 100.0],
@@ -842,6 +843,13 @@ class PstFromFlopyModel(object):
         )
         warnings.warn(dep_warn, DeprecationWarning)
 
+        if not HAS_FLOPY:
+            msg = (
+                "'PstFromFlopyModel' requires the 'flopy' package. Install it with "
+                "'pip install pyemu[optional]'."
+            )
+            raise ImportError(msg)
+
         self.logger = pyemu.logger.Logger("PstFromFlopyModel.log")
         self.log = self.logger.log
 
@@ -1205,10 +1213,8 @@ class PstFromFlopyModel(object):
 
         if isinstance(model, str):
             self.log("loading flopy model")
-            try:
-                import flopy
-            except:
-                raise Exception("from_flopy_model() requires flopy")
+            import flopy
+
             # prepare the flopy model
             self.org_model_ws = org_model_ws
             self.new_model_ws = new_model_ws
@@ -1263,6 +1269,8 @@ class PstFromFlopyModel(object):
         writes generic (ones) multiplier arrays
 
         """
+        import flopy
+        
         par_props = [
             self.pp_props,
             self.grid_props,
@@ -2374,6 +2382,7 @@ class PstFromFlopyModel(object):
         argument
 
         """
+        import flopy
 
         raw = pakattr.lower().split(".")
         if len(raw) != 2:

--- a/pyemu/legacy/pstfromflopy.py
+++ b/pyemu/legacy/pstfromflopy.py
@@ -17,7 +17,7 @@ from pyemu.utils import (
 )
 from pyemu.utils.helpers import _write_df_tpl
 
-HAS_FLOPY= importlib.util.find_spec("matplotlib") is not None
+HAS_FLOPY = importlib.util.find_spec("flopy") is not None
 
 wildass_guess_par_bounds_dict = {
     "hk": [0.01, 100.0],

--- a/pyemu/plot/plot_utils.py
+++ b/pyemu/plot/plot_utils.py
@@ -11,7 +11,7 @@ from ..pyemu_warnings import PyemuWarning
 import importlib.util
 import pyemu
 
-HAS_MATPLOTLIB= importlib.util.find_spec("matplotlib") is not None
+HAS_MATPLOTLIB = importlib.util.find_spec("matplotlib") is not None
 
 font = {"font.size": 6}
 

--- a/pyemu/plot/plot_utils.py
+++ b/pyemu/plot/plot_utils.py
@@ -8,18 +8,12 @@ import string
 from pyemu.logger import Logger
 from pyemu.pst import pst_utils
 from ..pyemu_warnings import PyemuWarning
+import importlib.util
+import pyemu
+
+HAS_MATPLOTLIB= importlib.util.find_spec("matplotlib") is not None
 
 font = {"font.size": 6}
-try:
-    import matplotlib
-    import matplotlib.pyplot as plt
-    from matplotlib.backends.backend_pdf import PdfPages
-    from matplotlib.gridspec import GridSpec
-except Exception as e:
-    # raise Exception("error importing matplotlib: {0}".format(str(e)))
-    warnings.warn("error importing matplotlib: {0}".format(str(e)), PyemuWarning)
-
-import pyemu
 
 figsize = (8, 10.5)
 nr, nc = 4, 2
@@ -32,6 +26,10 @@ def apply_custom_font(rc_params=None):
         rc_params = font
     def decorator(func):
         def wrapper(*args, **kwargs):
+            if not HAS_MATPLOTLIB:
+                return func(*args, **kwargs)
+
+            import matplotlib.pyplot as plt
             with plt.rc_context(rc_params):
                 return func(*args, **kwargs)
         return wrapper
@@ -268,6 +266,9 @@ def phi_progress(pst, logger=None, filename=None, **kwargs):
         plt.show()
 
     """
+    _ensure_matplotlib()
+    import matplotlib.pyplot as plt
+
     if logger is None:
         logger = Logger("Default_Logger.log", echo=False)
     logger.log("plot phi_progress")
@@ -292,6 +293,8 @@ def phi_progress(pst, logger=None, filename=None, **kwargs):
 
 
 def _get_page_axes(count=nr * nc):
+    import matplotlib.pyplot as plt
+
     axes = [plt.subplot(nr, nc, i + 1) for i in range(min(count, nr * nc))]
     # [ax.set_yticks([]) for ax in axes]
     return axes
@@ -326,6 +329,16 @@ def res_1to1(
         plt.show()
 
     """
+    if not HAS_MATPLOTLIB:
+        msg = (
+            "'res_1to1' requires the 'matplotlib' package. Install it "
+            "with 'pip install pyemu[optional]'."
+        )
+        raise ImportError(msg)
+
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_pdf import PdfPages
+
     if logger is None:
         logger = Logger("Default_Logger.log", echo=False)
     logger.log("plot res_1to1")
@@ -534,6 +547,10 @@ def plot_id_bar(id_df, nsv=None, logger=None, **kwargs):
         pyemu.plot_utils.plot_id_bar(id_df, nsv=12, figsize=(12,4)
 
     """
+    _ensure_matplotlib()
+    import matplotlib.colors
+    import matplotlib.pyplot as plt
+
     if logger is None:
         logger = Logger("Default_Logger.log", echo=False)
     logger.log("plot id bar")
@@ -632,6 +649,9 @@ def res_phi_pie(pst, logger=None, **kwargs):
 
 
     """
+    _ensure_matplotlib()
+    import matplotlib.pyplot as plt
+
     if logger is None:
         logger = Logger("Default_Logger.log", echo=False)
     logger.log("plot res_phi_pie")
@@ -725,6 +745,10 @@ def pst_prior(pst, logger=None, filename=None, **kwargs):
         plt.show()
 
     """
+    _ensure_matplotlib()
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_pdf import PdfPages
+
     if logger is None:
         logger = Logger("Default_Logger.log", echo=False)
     logger.log("plot pst_prior")
@@ -916,6 +940,10 @@ def ensemble_helper(
 
 
     """
+    _ensure_matplotlib()
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_pdf import PdfPages
+
     logger = pyemu.Logger("ensemble_helper.log")
     logger.log("pyemu.plot_utils.ensemble_helper()")
     ensembles = _process_ensemble_arg(ensemble, facecolor, logger)
@@ -1144,6 +1172,10 @@ def ensemble_change_summary(
 
 
     """
+    _ensure_matplotlib()
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_pdf import PdfPages
+
     if logger is None:
         logger = Logger("Default_Logger.log", echo=False)
     logger.log("plot ensemble change")
@@ -1403,6 +1435,11 @@ def ensemble_res_1to1(
         plt.show()
 
     """
+    _ensure_matplotlib()
+    import matplotlib.pyplot as plt
+    import matplotlib.ticker
+    from matplotlib.backends.backend_pdf import PdfPages
+
     def _get_plotlims(oen, ben, obsnames):
         if not isinstance(oen, dict):
             oen = {'g': oen.loc[:, obsnames]}
@@ -1696,6 +1733,8 @@ def plot_jac_test(
         to put into a separate directory and view the files.
 
     """
+    _ensure_matplotlib()
+    import matplotlib.pyplot as plt
 
     localhome = os.getcwd()
     # check if the output directory exists, if not make it
@@ -1794,3 +1833,11 @@ def plot_jac_test(
                     )
                 )
             plt.close()
+
+def _ensure_matplotlib():
+    if not HAS_MATPLOTLIB:
+        msg = (
+            "Plotting functions require the 'matplotlib' package. Install it "
+            "with 'pip install matplotlib'."
+        )
+        raise ImportError(msg)


### PR DESCRIPTION
Resolves #647

I was pleasantly surprised how little needed to be changed.

For reference, I used this `ruff.toml` config to help with this:

<details>

```TOML
exclude = [
    "autotest",
    "docs",
    "examples",
    "misc",
    "verification",
]
[lint]
select = ["TID"]
ignore = ["TID252"]
[lint.flake8-tidy-imports]
banned-module-level-imports = [
    "flopy",
    "matplotlib",
    "pyshp",
    "scipy",
    "shapely",
    "jinja2",
    "pypestutils",
    "scikit-learn",
]
[lint.per-file-ignores]
"*.ipynb" = ["TID"]
```

</details>