### PR TITLE
Fix shapefile field type handling for pandas StringDtype

### DIFF
--- a/pyemu/utils/pp_utils.py
+++ b/pyemu/utils/pp_utils.py
@@ -289,7 +289,9 @@ def setup_pilotpoints_grid(
         except:
             shp = shapefile.Writer(shapeType=shapefile.POINT)
         for name, dtype in par_info.dtypes.items():
-            if dtype == object:
+            dtype_str = str(dtype)
+            # Handle string types (pandas.StringDtype shows as 'str' in Pandas +3.0)
+            if dtype_str == 'str' or dtype_str == 'object' or dtype == object:
                 shp.field(name, "C", size=50)
             elif dtype in [int]:#, np.int64, np.int32]:
                 shp.field(name, "N", size=50, decimal=0)


### PR DESCRIPTION
## Description
Fixes issue with shapefile Writer when pandas DataFrames use `StringDtype` instead of object dtype for string columns.

## Problem
When using pandas 3.0+ string columns (dtype='string' or `pd.StringDtype()`), the shapefile writer raised:
```
unrecognized field type in par_info:name:str
```

This occurs because pandas 3.0 introduced `StringDtype` as the default for string columns, which returns `'str'` when converted to string, rather than `'object'` as in previous pandas versions.

## Solution
Added check for `str(dtype) == 'str'` to properly handle pandas `StringDtype` columns alongside the existing object dtype check.

## Changes
- Modified dtype checking in `pp_utils.py` to recognize `str(dtype) == 'str'`
- Maintains backward compatibility with older pandas versions using object dtype