### PR TITLE
Fix smp_to_ins for SMP files with leading whitespace

### DIFF
--- a/autotest/utils_tests.py
+++ b/autotest/utils_tests.py
@@ -2019,6 +2019,120 @@ def smp_test(tmp_path):
     print(len(obs_names))
 
 
+def smp_to_ins_leading_whitespace_test(tmp_path):
+    """Test that smp_to_ins handles leading whitespace correctly in both
+    free format (gwutils_compliant=False) and fixed format
+    (gwutils_compliant=True) modes.
+
+    The PEST 'w' instruction treats leading whitespace differently:
+    it consumes one 'w' to skip past leading blanks without advancing
+    past a word. Files with leading whitespace need an extra 'w' marker
+    in free format, and correct column ranges in fixed format.
+
+    See: https://github.com/pypest/pyemu/issues/361
+    """
+    import os
+    from pyemu.utils import smp_to_ins
+    from pyemu.pst.pst_utils import parse_ins_file
+
+    # Create an SMP file WITH leading whitespace (like mod2smp output)
+    smp_leading = os.path.join(tmp_path, "leading.smp")
+    with open(smp_leading, "w") as f:
+        f.write(" well_01     01/01/2000    00:00:00    1.230000\n")
+        f.write(" well_01     02/01/2000    00:00:00    4.560000\n")
+        f.write(" well_02     01/01/2000    00:00:00    7.890000\n")
+
+    # Create an SMP file WITHOUT leading whitespace
+    smp_no_leading = os.path.join(tmp_path, "no_leading.smp")
+    with open(smp_no_leading, "w") as f:
+        f.write("well_01     01/01/2000    00:00:00    1.230000\n")
+        f.write("well_01     02/01/2000    00:00:00    4.560000\n")
+        f.write("well_02     01/01/2000    00:00:00    7.890000\n")
+
+    # Test free format (gwutils_compliant=False) with leading whitespace
+    ins_file = os.path.join(tmp_path, "leading_free.ins")
+    df = smp_to_ins(smp_leading, ins_file, use_generic_names=True)
+    obs_names = parse_ins_file(ins_file)
+    assert len(obs_names) == 3
+    # Should have 4 'w' markers for leading whitespace
+    for ins_str in df["ins_strings"]:
+        assert ins_str.count(" w") == 4, (
+            "expected 4 'w' markers for leading whitespace, "
+            "got: {0}".format(ins_str)
+        )
+
+    # Test free format (gwutils_compliant=False) without leading whitespace
+    ins_file = os.path.join(tmp_path, "no_leading_free.ins")
+    df = smp_to_ins(smp_no_leading, ins_file, use_generic_names=True)
+    obs_names = parse_ins_file(ins_file)
+    assert len(obs_names) == 3
+    # Should have 3 'w' markers for no leading whitespace
+    for ins_str in df["ins_strings"]:
+        assert ins_str.count(" w") == 3, (
+            "expected 3 'w' markers for no leading whitespace, "
+            "got: {0}".format(ins_str)
+        )
+
+    # Test fixed format (gwutils_compliant=True) with leading whitespace
+    ins_file = os.path.join(tmp_path, "leading_fixed.ins")
+    df = smp_to_ins(
+        smp_leading, ins_file, use_generic_names=True, gwutils_compliant=True
+    )
+    obs_names = parse_ins_file(ins_file)
+    assert len(obs_names) == 3
+    # The value "1.230000" starts at column 45 in the leading-whitespace lines
+    # Verify the column range captures the value, not the time
+    for ins_str in df["ins_strings"]:
+        # Extract the column range from the instruction string
+        paren_end = ins_str.index(")")
+        col_range = ins_str[paren_end + 1:]
+        col_start, col_end = [int(x) for x in col_range.split(":")]
+        # Read the corresponding raw line and verify the range captures
+        # a parseable number (the value), not the time field
+        assert col_start > 35, (
+            "column range starts too early (likely reading time column), "
+            "got: {0}".format(ins_str)
+        )
+
+    # Test fixed format (gwutils_compliant=True) without leading whitespace
+    ins_file = os.path.join(tmp_path, "no_leading_fixed.ins")
+    df = smp_to_ins(
+        smp_no_leading, ins_file, use_generic_names=True, gwutils_compliant=True
+    )
+    obs_names = parse_ins_file(ins_file)
+    assert len(obs_names) == 3
+    for ins_str in df["ins_strings"]:
+        paren_end = ins_str.index(")")
+        col_range = ins_str[paren_end + 1:]
+        col_start, col_end = [int(x) for x in col_range.split(":")]
+        assert col_start > 34, (
+            "column range starts too early (likely reading time column), "
+            "got: {0}".format(ins_str)
+        )
+
+    # Test with the actual repo SMP files that have varying formats
+    o_smp_filename = os.path.join("misc", "gainloss.smp")
+    smp_filename = os.path.join(tmp_path, "gainloss_test.smp")
+    shutil.copy(o_smp_filename, smp_filename)
+    for gwutils in [True, False]:
+        ins_file = smp_filename + ".gwutils_{0}.ins".format(gwutils)
+        df = smp_to_ins(smp_filename, ins_file, gwutils_compliant=gwutils)
+        obs_names = parse_ins_file(ins_file)
+        assert len(obs_names) > 0
+
+    o_smp_filename = os.path.join("misc", "sim_hds_v6.smp")
+    smp_filename = os.path.join(tmp_path, "sim_hds_v6_test.smp")
+    shutil.copy(o_smp_filename, smp_filename)
+    for gwutils in [True, False]:
+        ins_file = smp_filename + ".gwutils_{0}.ins".format(gwutils)
+        df = smp_to_ins(
+            smp_filename, ins_file,
+            use_generic_names=True, gwutils_compliant=gwutils
+        )
+        obs_names = parse_ins_file(ins_file)
+        assert len(obs_names) > 0
+
+
 def smp_dateparser_test(tmp_path):
     import os
     import pyemu

--- a/pyemu/utils/smp_utils.py
+++ b/pyemu/utils/smp_utils.py
@@ -56,6 +56,16 @@ def smp_to_ins(
     if ins_filename is None:
         ins_filename = smp_filename + ".ins"
     df = smp_to_dataframe(smp_filename, datetime_format=datetime_format)
+
+    # Read raw lines for accurate instruction generation.
+    # The PEST 'w' instruction uses a two-step algorithm that treats
+    # leading whitespace differently: it consumes one 'w' to skip past
+    # leading blanks without advancing past a word. This means files
+    # with leading whitespace need an extra 'w' marker. For fixed format,
+    # the value column position depends on the actual file layout.
+    with open(smp_filename) as f:
+        raw_lines = [line for line in f.readlines() if line.strip()]
+
     df.loc[:, "ins_strings"] = None
     df.loc[:, "observation_names"] = None
     name_groups = df.groupby("name").groups
@@ -74,9 +84,26 @@ def smp_to_ins(
                 "observation names longer than 20 chars:\n{0}".format(str(long_names))
             )
         if gwutils_compliant:
-            ins_strs = ["l1  ({0:s})39:46".format(on) for on in onames]
+            ins_strs = []
+            for i, on in zip(idxs, onames):
+                raw_line = raw_lines[i].rstrip()
+                # Find the value column range (last whitespace-delimited token)
+                j = len(raw_line) - 1
+                while j >= 0 and raw_line[j] != ' ':
+                    j -= 1
+                val_start = j + 2  # 1-indexed for PEST
+                val_end = len(raw_line)  # 1-indexed, inclusive
+                ins_strs.append(
+                    "l1  ({0:s}){1:d}:{2:d}".format(on, val_start, val_end)
+                )
         else:
-            ins_strs = ["l1 w w w  !{0:s}!".format(on) for on in onames]
+            ins_strs = []
+            for i, on in zip(idxs, onames):
+                raw_line = raw_lines[i]
+                if raw_line[0] == ' ':
+                    ins_strs.append("l1 w w w w !{0:s}!".format(on))
+                else:
+                    ins_strs.append("l1 w w w !{0:s}!".format(on))
         df.loc[idxs, "observation_names"] = onames
         df.loc[idxs, "ins_strings"] = ins_strs
 


### PR DESCRIPTION
## Summary

Fixes the `smp_to_ins` instruction file generation for SMP files with leading whitespace (e.g. output from `mod2smp`).

The PEST `w` instruction uses a two-step cursor algorithm where leading whitespace consumes one `w` marker without advancing past a word. This caused `smp_to_ins` to generate incorrect instruction files:

- **Free format** (`gwutils_compliant=False`): now uses 4 `w` markers when leading whitespace is detected (3 when not), so the value column is correctly read instead of the time column.
- **Fixed format** (`gwutils_compliant=True`): dynamically determines the value column range from the actual SMP file layout instead of hardcoding `39:46`, which only worked for short site names without leading whitespace.

## Changes

- `pyemu/utils/smp_utils.py`: reads raw SMP lines to detect leading whitespace and compute correct column positions
- `autotest/utils_tests.py`: adds `smp_to_ins_leading_whitespace_test` covering both modes with and without leading whitespace, plus the existing repo SMP test files

## Test plan

- [x] New test `smp_to_ins_leading_whitespace_test` passes
- [x] Existing tests `smp_test`, `smp_to_ins_test`, `smp_dateparser_test` still pass

Fixes #361