### PR TITLE
Add "auto" option to OrdinaryKrigingPPU

### DIFF
--- a/pyemu/utils/geostats.py
+++ b/pyemu/utils/geostats.py
@@ -796,7 +796,11 @@ class OrdinaryKrigePPU(object):
 
         assert isinstance(auto, bool), "auto must be a boolean"
         self.auto = auto
-    
+
+        if self.auto:
+            print("Warning: OrdinaryKrigingPPU's Auto argument is set to true." \
+            "Variograms will be determined by pypestutils. " \
+            "Ignoring user-provided variogram and search radius parameters.")
 
         if not express:
             self.check_names()
@@ -947,6 +951,20 @@ class OrdinaryKrigePPU(object):
         search_radius = kwargs.get("search_dist", kwargs.get('search_radius',1.0e10))
 
         if self.auto:
+            num_interp_pts = plib.calc_kriging_factors_auto_2d(
+                self.point_data.x.values,  # source xs
+                self.point_data.y.values,  # source ys
+                self.point_data.zone.values,  # source zones
+                x.ravel(), # target xs
+                y.ravel(), # target ys
+                zone_array.ravel().astype(int), # target zones
+                krigtype,
+                aniso,
+                bearing,
+                fac_fname,
+                factorfiletype
+            )
+        else:
             num_interp_pts = plib.calc_kriging_factors_2d(
                 self.point_data.x.values,  # source xs
                 self.point_data.y.values,  # source ys
@@ -962,19 +980,6 @@ class OrdinaryKrigePPU(object):
                 search_radius,
                 maxpts_interp,
                 minpts_interp,
-                fac_fname,
-                factorfiletype
-            )
-        else:
-            num_interp_pts = plib.calc_kriging_factors_auto_2d(
-                self.point_data.x.values,  # source xs
-                self.point_data.y.values,  # source ys
-                self.point_data.zone.values,  # source zones
-                x.ravel(), # target xs
-                y.ravel(), # target ys
-                zone_array.ravel().astype(int), # target zones
-                aniso,
-                bearing,
                 fac_fname,
                 factorfiletype
             )

--- a/pyemu/utils/geostats.py
+++ b/pyemu/utils/geostats.py
@@ -760,13 +760,17 @@ class OrdinaryKrigePPU(object):
 
     Off-loading the much of the computational effort to Pypestutils.
     """
-    def __init__(self, geostruct, point_data, express=False):
+    def __init__(self, geostruct, point_data, express=False, auto=False):
         """Initialize OrdinaryKrigePPU object.
 
         Args:
             geostruct None: Dummy argument to match OrdinaryKrige signature.
             point_data (`pandas.DataFrame`): the conditioning points to use for kriging.
                 `point_data` must contain columns "name", "x", "y". Optionally "zone".
+            auto (bool): if set to true, use pypestutil's auto krige function, which 
+                automatically estimates search radius and variogram parameters
+                based on pilot point density
+
 
         Note:
             if `point_data` is an `str`, then it is assumed to be a pilot points file
@@ -789,6 +793,10 @@ class OrdinaryKrigePPU(object):
         assert "y" in point_data.columns, "point_data missing 'y'"
 
         self.point_data = point_data
+
+        assert isinstance(auto, bool), "auto must be a boolean"
+        self.auto = auto
+    
 
         if not express:
             self.check_names()
@@ -938,24 +946,38 @@ class OrdinaryKrigePPU(object):
         maxpts_interp = kwargs.get('maxpts_interp',50)
         search_radius = kwargs.get("search_dist", kwargs.get('search_radius',1.0e10))
 
-        num_interp_pts = plib.calc_kriging_factors_2d(
-            self.point_data.x.values,  # source xs
-            self.point_data.y.values,  # source ys
-            self.point_data.zone.values,  # source zones
-            x.ravel(), # target xs
-            y.ravel(), # target ys
-            zone_array.ravel().astype(int), # target zones
-            vartype,
-            krigtype,
-            corrlen,
-            aniso,
-            bearing,
-            search_radius,
-            maxpts_interp,
-            minpts_interp,
-            fac_fname,
-            factorfiletype
-        )
+        if self.auto:
+            num_interp_pts = plib.calc_kriging_factors_2d(
+                self.point_data.x.values,  # source xs
+                self.point_data.y.values,  # source ys
+                self.point_data.zone.values,  # source zones
+                x.ravel(), # target xs
+                y.ravel(), # target ys
+                zone_array.ravel().astype(int), # target zones
+                vartype,
+                krigtype,
+                corrlen,
+                aniso,
+                bearing,
+                search_radius,
+                maxpts_interp,
+                minpts_interp,
+                fac_fname,
+                factorfiletype
+            )
+        else:
+            num_interp_pts = plib.calc_kriging_factors_auto_2d(
+                self.point_data.x.values,  # source xs
+                self.point_data.y.values,  # source ys
+                self.point_data.zone.values,  # source zones
+                x.ravel(), # target xs
+                y.ravel(), # target ys
+                zone_array.ravel().astype(int), # target zones
+                aniso,
+                bearing,
+                fac_fname,
+                factorfiletype
+            )
         if self.lib is None: # if not context managed
             plib.free_all_memory()
         assert os.path.exists(fac_fname)


### PR DESCRIPTION
This (hopefully simple) PR adds an optional bool argument "auto" to OrdinaryKrigingPPU. When set to true, the auto_2d krige function is called in place of the regular 2d krige function in pypestutils. This results in variogram parameters being automatically calculated. Anisotropy and bearing parameters are still used, but all other variogram parameters which are normally user supplied (a, sill, nugget, search radius, etc.) are not used by the auto function.