### PR TITLE
Fix setup_pilotpoints_grid missing pilot points for misaligned/small zones

### DIFF
--- a/autotest/investigate_pp_search_impact.py
+++ b/autotest/investigate_pp_search_impact.py
@@ -1,0 +1,295 @@
+"""
+Investigate the impact of the setup_pilotpoints_grid search-loop fix
+(pyemu/utils/pp_utils.py, structured-grid branch) across several ibound/
+zone scenarios.
+
+Compares:
+  - old_search(): a standalone re-implementation of the pre-fix,
+    global-stride search loop (row/col loop anchored to the full array).
+  - the new (current) pyemu.pp_utils.setup_pilotpoints_grid, called
+    through the real public API - including its MIN_KRIGE_PPOINTS floor
+    (raises if a zone yields < 3 points) and dense-fallback cap.
+
+This is a throwaway investigation script (not part of the test suite) -
+results are printed to stdout, and a figure comparing the zone rasters and
+old-vs-new pilot point locations for each scenario is saved next to this
+script as investigate_pp_search_impact.png.
+"""
+import os
+import shutil
+import sys
+import tempfile
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+REPO = "/Users/brioch/Projects/dev/pyemu"
+sys.path.insert(0, REPO)
+sys.path.insert(0, os.path.join(REPO, "autotest"))
+
+import pyemu
+
+
+def old_search(ib, every_n_cell, use_ibound_zones):
+    """Re-implementation of the pre-fix search loop (global-array-anchored
+    stride) exactly as it existed at pp_utils.py:217-237 before the fix."""
+    start = int(float(every_n_cell) / 2.0)
+    start_row = 0 if ib.shape[0] == 1 else start
+    start_col = 0 if ib.shape[1] == 1 else start
+    hits = []
+    for i in range(start_row, ib.shape[0] - start_row // 2, every_n_cell):
+        for j in range(start_col, ib.shape[1] - start_col // 2, every_n_cell):
+            if ib[i, j] <= 0:
+                continue
+            zone = ib[i, j] if use_ibound_zones else 1
+            hits.append((i, j, zone))
+    return hits
+
+
+def make_sr(nrow, ncol, delr=100.0, delc=100.0):
+    return pyemu.helpers.SpatialReference(
+        delr=[delr] * ncol, delc=[delc] * nrow, rotation=0, epsg=3070,
+        xul=0.0, yul=0.0, units="meters", lenuni=2,
+    )
+
+
+def new_search(ib, sr, every_n_cell, use_ibound_zones, tmp_path):
+    """Run the real (current) setup_pilotpoints_grid. May raise if a zone
+    can't produce MIN_KRIGE_PPOINTS - callers should catch that."""
+    par_info = pyemu.pp_utils.setup_pilotpoints_grid(
+        sr=sr, ibound=ib, prefix_dict={0: "hk1_"}, every_n_cell=every_n_cell,
+        use_ibound_zones=use_ibound_zones,
+        pp_dir=tmp_path, tpl_dir=tmp_path, shapename=None,
+    )
+    return [(int(r.i), int(r.j), r.zone) for r in par_info.itertuples()]
+
+
+def run_scenario(ib, sr, every_n_cell, use_ibound_zones, tmp_path):
+    """Run both the old and new search, catching any exception the new
+    (current) implementation raises so one bad scenario doesn't kill the
+    rest of the investigation."""
+    old_hits = old_search(ib, every_n_cell, use_ibound_zones)
+    new_err = None
+    try:
+        new_hits = new_search(ib, sr, every_n_cell, use_ibound_zones, tmp_path)
+    except Exception as e:
+        new_hits = []
+        new_err = str(e)
+    return old_hits, new_hits, new_err
+
+
+def summarize(name, ib, old_hits, new_hits, new_err=None, by_zone=False):
+    n_active = int((ib > 0).sum())
+    print(f"\n=== {name} ===")
+    print(f"grid shape={ib.shape}, active cells={n_active}")
+    print(f"  old search: {len(old_hits)} pilot point(s)"
+          + ("  <-- BUG: zone has active cells but old search found none" if len(old_hits) == 0 and n_active > 0 else ""))
+    if new_err:
+        print(f"  new search: RAISED -- {new_err}")
+    else:
+        print(f"  new search: {len(new_hits)} pilot point(s)")
+    if by_zone and not new_err:
+        for zone in sorted(set(z for *_, z in old_hits) | set(z for *_, z in new_hits)):
+            n_old = sum(1 for *_, z in old_hits if z == zone)
+            n_new = sum(1 for *_, z in new_hits if z == zone)
+            print(f"    zone {zone}: old={n_old}, new={n_new}")
+
+
+def nn_stats(hits):
+    if len(hits) < 2:
+        return None
+    pts = np.array([(i, j) for i, j, z in hits])
+    dmin = []
+    for k in range(len(pts)):
+        d = np.sqrt(((pts - pts[k]) ** 2).sum(axis=1))
+        d[k] = np.inf
+        dmin.append(d.min())
+    return {"min_nn_dist": float(np.min(dmin)), "mean_nn_dist": float(np.mean(dmin)), "max_nn_dist": float(np.max(dmin))}
+
+
+def plot_scenario(ax, name, ib, old_hits, new_hits, new_err=None, by_zone=False):
+    """Show the zone/ibound raster with the old- vs new-search pilot point
+    locations overlaid, so the two can be compared visually in one panel.
+    If by_zone, color pilot points by their zone id (marker shape still
+    distinguishes old 'x' vs new 'o') instead of a flat red/cyan, so
+    multi-zone scenarios are easier to read."""
+    ax.imshow(ib, origin="upper", cmap="tab20", interpolation="nearest")
+    if by_zone:
+        zones = sorted(set(z for *_, z in old_hits) | set(z for *_, z in new_hits))
+        palette = plt.get_cmap("Dark2")
+        zone_color = {z: palette(i % 8) for i, z in enumerate(zones)}
+        for z in zones:
+            pts = [(i, j) for i, j, zz in old_hits if zz == z]
+            if pts:
+                oi, oj = zip(*pts)
+                ax.scatter(oj, oi, marker="x", color=zone_color[z], s=50,
+                           linewidths=1.5, label=f"old zone {z} ({len(pts)})")
+        for z in zones:
+            pts = [(i, j) for i, j, zz in new_hits if zz == z]
+            if pts:
+                ni, nj = zip(*pts)
+                ax.scatter(nj, ni, marker="o", facecolors="none",
+                           edgecolors=[zone_color[z]], s=70, linewidths=1.5,
+                           label=f"new zone {z} ({len(pts)})")
+    else:
+        if old_hits:
+            oi, oj = zip(*[(i, j) for i, j, z in old_hits])
+            ax.scatter(oj, oi, marker="x", c="red", s=50, linewidths=1.5,
+                       label=f"old ({len(old_hits)})")
+        if new_hits:
+            ni, nj = zip(*[(i, j) for i, j, z in new_hits])
+            ax.scatter(nj, ni, marker="o", facecolors="none",
+                       edgecolors="cyan", s=70, linewidths=1.5,
+                       label=f"new ({len(new_hits)})")
+    if new_err:
+        ax.text(0.5, 0.5, "new search RAISED\n(< MIN_KRIGE_PPOINTS)",
+                transform=ax.transAxes, ha="center", va="center", fontsize=8,
+                color="yellow", weight="bold",
+                bbox=dict(facecolor="black", alpha=0.6, boxstyle="round"))
+        for spine in ax.spines.values():
+            spine.set_edgecolor("red")
+            spine.set_linewidth(3)
+    ax.set_title(name, fontsize=8)
+    ax.set_xticks([])
+    ax.set_yticks([])
+    if old_hits or new_hits:
+        ax.legend(fontsize=6, loc="upper right", framealpha=0.7)
+
+
+scenarios = []  # (name, ib, old_hits, new_hits, new_err, by_zone) collected for plotting
+
+with tempfile.TemporaryDirectory() as tmp_path:
+    every_n_cell = 4
+
+    # 1) baseline: full active grid, single zone - should match exactly
+    nrow, ncol = 20, 20
+    ib = np.ones((nrow, ncol), dtype=int)
+    sr = make_sr(nrow, ncol)
+    old_hits, new_hits, err = run_scenario(ib, sr, every_n_cell, False, tmp_path)
+    name = "1) full active grid (baseline equivalence check)"
+    summarize(name, ib, old_hits, new_hits, err)
+    assert err is None and sorted(old_hits) == sorted(new_hits), "REGRESSION: baseline full-grid case changed!"
+    print("  -> IDENTICAL to old algorithm (as expected)")
+    scenarios.append((name, ib, old_hits, new_hits, err, False))
+
+    # 2) thin band off the stride grid (same as the new autotest case)
+    nrow, ncol = 20, 20
+    ib = np.zeros((nrow, ncol), dtype=int)
+    ib[7:10, :] = 1
+    sr = make_sr(nrow, ncol)
+    old_hits, new_hits, err = run_scenario(ib, sr, every_n_cell, False, tmp_path)
+    name = "2) thin band missed by global stride"
+    summarize(name, ib, old_hits, new_hits, err)
+    if not err:
+        print(f"  new hit rows: {sorted(set(i for i, j, z in new_hits))}")
+    scenarios.append((name, ib, old_hits, new_hits, err, False))
+
+    # 3) small isolated blob, off-grid, inside a big mostly-inactive domain
+    #    - small enough (3x3, thinner than every_n_cell in both axes) that
+    #    the direct search only checks a single midpoint candidate, but the
+    #    fallback (now triggered whenever hits < MIN_KRIGE_PPOINTS, not
+    #    just when hits is empty) picks up the blob's other active cells
+    #    instead of raising
+    nrow, ncol = 50, 50
+    ib = np.zeros((nrow, ncol), dtype=int)
+    ib[23:26, 31:34] = 1  # 3x3 blob, deliberately not aligned to stride 4
+    sr = make_sr(nrow, ncol)
+    old_hits, new_hits, err = run_scenario(ib, sr, every_n_cell, False, tmp_path)
+    name = "3) small isolated 3x3 blob, off-grid (fallback, not raise)"
+    summarize(name, ib, old_hits, new_hits, err)
+    scenarios.append((name, ib, old_hits, new_hits, err, False))
+
+    # 4) irregular (non-rectangular / diagonal) zone shape - exercises the
+    #    dense-fallback safety net
+    nrow, ncol = 30, 30
+    ib = np.zeros((nrow, ncol), dtype=int)
+    for k in range(30):
+        ib[k, (k * 2) % 30] = 1  # scattered diagonal-ish pattern
+    sr = make_sr(nrow, ncol)
+    old_hits, new_hits, err = run_scenario(ib, sr, every_n_cell, False, tmp_path)
+    name = "4) scattered/irregular zone shape (fallback path)"
+    summarize(name, ib, old_hits, new_hits, err)
+    if not err:
+        print(f"  fallback triggered: {len(new_hits) == int((ib > 0).sum())}")
+    scenarios.append((name, ib, old_hits, new_hits, err, False))
+
+    # 5) multi-zone map, use_ibound_zones=True, with one zone split into
+    #    two disjoint patches sharing the same zone id
+    nrow, ncol = 40, 40
+    ib = np.ones((nrow, ncol), dtype=int)  # zone 1 = background
+    ib[5:9, 5:35] = 2       # zone 2, patch A (thin band, off-stride)
+    ib[31:35, 5:35] = 2     # zone 2, patch B (same zone id, disjoint)
+    sr = make_sr(nrow, ncol)
+    old_hits, new_hits, err = run_scenario(ib, sr, every_n_cell, True, tmp_path)
+    name = "5) multi-zone, disjoint same-id zone 2 (use_ibound_zones=True)"
+    summarize(name, ib, old_hits, new_hits, err, by_zone=True)
+    if not err:
+        zone2_old_rows = sorted(set(i for i, j, z in old_hits if z == 2))
+        zone2_new_rows = sorted(set(i for i, j, z in new_hits if z == 2))
+        print(f"  zone 2 rows hit -- old: {zone2_old_rows}  new: {zone2_new_rows}")
+    scenarios.append((name, ib, old_hits, new_hits, err, True))
+
+    # 6) same multi-zone map, nearest-neighbor spacing sanity check for the
+    #    dominant zone (zone 1) to confirm per-zone anchoring doesn't
+    #    degrade spacing/regularity for the common case
+    if not err:
+        old_zone1 = [(i, j, z) for i, j, z in old_hits if z == 1]
+        new_zone1 = [(i, j, z) for i, j, z in new_hits if z == 1]
+        print(f"\n  zone 1 nn-dist stats -- old: {nn_stats(old_zone1)}")
+        print(f"  zone 1 nn-dist stats -- new: {nn_stats(new_zone1)}")
+
+    # 7) real Freyberg extra_crispy model ibound, default (use_ibound_zones=False)
+    try:
+        import flopy
+        o_model_ws = os.path.join(REPO, "examples", "Freyberg", "extra_crispy")
+        model_ws = os.path.join(tmp_path, "extra_crispy")
+        shutil.copytree(o_model_ws, model_ws)
+        ml = flopy.modflow.Modflow.load("freyberg.nam", model_ws=model_ws, check=False)
+        ib_real = ml.bas6.ibound.array[0]
+        sr_real = pyemu.helpers.SpatialReference.from_namfile(
+            os.path.join(ml.model_ws, ml.namefile), delc=ml.dis.delc, delr=ml.dis.delr)
+        sr_real.rotation = 0.0
+        old_hits, new_hits, err = run_scenario(ib_real, sr_real, 2, False, tmp_path)
+        name = "7) real Freyberg extra_crispy ibound (mix of 1/0/-1)"
+        summarize(name, ib_real, old_hits, new_hits, err)
+        assert err is None and sorted(old_hits) == sorted(new_hits), "REGRESSION: real Freyberg ibound case changed!"
+        print("  -> IDENTICAL to old algorithm (as expected, single contiguous active zone)")
+        scenarios.append((name, ib_real, old_hits, new_hits, err, False))
+    except Exception as e:
+        print(f"\n=== 7) real Freyberg ibound check skipped: {e} ===")
+
+    # 8) dense-fallback cap check: a large zone that fully aliases against
+    #    the stride (forcing the empty-hits fallback) should be decimated
+    #    back down, not explode into one pilot point per active cell
+    nrow, ncol = 400, 400
+    ib = np.zeros((nrow, ncol), dtype=int)
+    col = 200
+    for i in range(1, 399):
+        if i % 4 != 3:
+            ib[i, col] = 1
+    sr = make_sr(nrow, ncol)
+    old_hits, new_hits, err = run_scenario(ib, sr, every_n_cell, False, tmp_path)
+    name = "8) dense aliased zone - fallback cap check"
+    summarize(name, ib, old_hits, new_hits, err)
+    if not err:
+        print(f"  n_active={int((ib > 0).sum())}, capped new count={len(new_hits)}")
+    scenarios.append((name, ib, old_hits, new_hits, err, False))
+
+print("\nDone.")
+
+# --- plotting: zone raster + old-vs-new pilot point locations, one panel
+#     per scenario ---
+ncols_fig = 3
+nrows_fig = int(np.ceil(len(scenarios) / ncols_fig))
+fig, axes = plt.subplots(nrows_fig, ncols_fig, figsize=(5 * ncols_fig, 4.5 * nrows_fig))
+axes = np.atleast_1d(axes).flatten()
+for ax, (name, ib, old_hits, new_hits, err, by_zone) in zip(axes, scenarios):
+    plot_scenario(ax, name, ib, old_hits, new_hits, err, by_zone=by_zone)
+for ax in axes[len(scenarios):]:
+    ax.axis("off")
+fig.suptitle("setup_pilotpoints_grid search fix: zones + old vs new pilot points", fontsize=12)
+fig.tight_layout(rect=[0, 0, 1, 0.96])
+
+out_png = os.path.join(os.path.dirname(__file__), "investigate_pp_search_impact.png")
+fig.savefig(out_png, dpi=130)
+print(f"\nSaved comparison figure to: {out_png}")

--- a/autotest/utils_tests.py
+++ b/autotest/utils_tests.py
@@ -472,6 +472,282 @@ def test_setup_pp(tmp_path):
     # print(par_info_rot.x)
 
 
+def test_setup_pp_misses_offgrid_active_zone(tmp_path):
+    """Exposes pp_utils.py L220-224: the fixed every_n_cell stride search
+    can skip real active zones entirely if none of their cells align with
+    the sampled (i, j) locations, even though ibound has active cells -
+    plenty of them, and enough to support pilot point interpolation, if
+    only the search actually found them.
+    """
+    import numpy as np
+    import pyemu
+
+    nrow, ncol = 20, 20
+    every_n_cell = 4
+    sr = pyemu.helpers.SpatialReference(
+        delr=[100.0] * ncol,
+        delc=[100.0] * nrow,
+        rotation=0,
+        epsg=3070,
+        xul=0.0,
+        yul=0.0,
+        units="meters",
+        lenuni=2,
+    )
+    # with every_n_cell=4, start = int(4/2) = 2, so the search loop only
+    # ever visits rows/cols in {2, 6, 10, 14, 18} (pp_utils.py L220-224:
+    # range(start_row, nrow - start_row//2, every_n_cell)).
+    sampled_rows = set(range(2, nrow - 1, every_n_cell))
+    assert sampled_rows == {2, 6, 10, 14, 18}
+
+    ibound = np.zeros((nrow, ncol), dtype=int)
+    # a realistic, contiguous active zone (e.g. a channel deposit) spanning
+    # the full width of the grid - 60 active cells, easily enough to
+    # support kriging/interpolation - but rows 7-9 fall entirely in the gap
+    # between sampled rows 6 and 10, so the search never sees any of them.
+    ibound[7:10, :] = 1
+
+    par_info = pyemu.pp_utils.setup_pilotpoints_grid(
+        sr=sr,
+        ibound=ibound,
+        prefix_dict={0: "hk1_"},
+        every_n_cell=every_n_cell,
+        pp_dir=tmp_path,
+        tpl_dir=tmp_path,
+        shapename=None,
+    )
+    assert not par_info.empty, (
+        "no pilot points were generated even though ibound has 60 active "
+        "cells - the fixed-stride i,j search missed them entirely"
+    )
+
+
+def test_setup_pp_too_few_points_raises(tmp_path):
+    """A zone with too few active cells to support kriging (< 3 points,
+    pp_utils.MIN_KRIGE_PPOINTS) can never be interpolated (a singular
+    kriging system), so setup_pilotpoints_grid should fail fast with a
+    clear error instead of silently returning an under-determined pilot
+    point set.
+    """
+    import numpy as np
+    import pyemu
+
+    nrow, ncol = 20, 20
+    sr = pyemu.helpers.SpatialReference(
+        delr=[100.0] * ncol,
+        delc=[100.0] * nrow,
+        rotation=0,
+        epsg=3070,
+        xul=0.0,
+        yul=0.0,
+        units="meters",
+        lenuni=2,
+    )
+    ibound = np.zeros((nrow, ncol), dtype=int)
+    ibound[0, 0] = 1  # single active cell in this zone/layer
+
+    with pytest.raises(Exception, match="fewer than the .* well-posed"):
+        pyemu.pp_utils.setup_pilotpoints_grid(
+            sr=sr,
+            ibound=ibound,
+            prefix_dict={0: "hk1_"},
+            every_n_cell=4,
+            pp_dir=tmp_path,
+            tpl_dir=tmp_path,
+            shapename=None,
+        )
+
+
+def test_setup_pp_small_zone_uses_fallback_instead_of_raising(tmp_path):
+    """A zone too thin (in both axes) for even one full stride step gets
+    only a single midpoint candidate from the direct search - but if the
+    zone actually has enough active cells to clear MIN_KRIGE_PPOINTS, the
+    fallback (now triggered whenever hits < MIN_KRIGE_PPOINTS, not just
+    when hits is empty) should use them instead of raising.
+    """
+    import numpy as np
+    import pyemu
+
+    nrow, ncol = 50, 50
+    sr = pyemu.helpers.SpatialReference(
+        delr=[100.0] * ncol,
+        delc=[100.0] * nrow,
+        rotation=0,
+        epsg=3070,
+        xul=0.0,
+        yul=0.0,
+        units="meters",
+        lenuni=2,
+    )
+    ibound = np.zeros((nrow, ncol), dtype=int)
+    ibound[23:26, 31:34] = 1  # 3x3 blob (9 active cells) - thinner than
+    # every_n_cell=4 on both axes, so the direct search only checks its
+    # single midpoint
+
+    par_info = pyemu.pp_utils.setup_pilotpoints_grid(
+        sr=sr,
+        ibound=ibound,
+        prefix_dict={0: "hk1_"},
+        every_n_cell=4,
+        pp_dir=tmp_path,
+        tpl_dir=tmp_path,
+        shapename=None,
+    )
+    # exact count depends on the fallback's bucketing, but it must clear
+    # the kriging floor without using every single active cell
+    assert pyemu.pp_utils.MIN_KRIGE_PPOINTS <= len(par_info) < 9
+
+
+def test_setup_pp_under_delivery_warns(tmp_path):
+    """A zone with enough active cells to clear the MIN_KRIGE_PPOINTS floor,
+    but scattered such that most of the every_n_cell stride locations
+    implied by its bounding box miss the active cells entirely, should warn
+    that the search under-delivered relative to what was requested -
+    without raising, since the points that were found (via the dense
+    fallback) are still enough to support kriging.
+    """
+    import warnings
+    import numpy as np
+    import pyemu
+    from pyemu.pyemu_warnings import PyemuWarning
+
+    nrow, ncol = 30, 30
+    sr = pyemu.helpers.SpatialReference(
+        delr=[100.0] * ncol,
+        delc=[100.0] * nrow,
+        rotation=0,
+        epsg=3070,
+        xul=0.0,
+        yul=0.0,
+        units="meters",
+        lenuni=2,
+    )
+    ibound = np.zeros((nrow, ncol), dtype=int)
+    # a thin diagonal "fault trace" zone - its bounding box (rows/cols 2-26)
+    # is large enough that every_n_cell=4 nominally requests a 6x6=36-point
+    # grid, but almost none of those stride locations land on the diagonal,
+    # so only the 7 actual active cells (via the fallback) get used
+    diag_idx = [2, 6, 10, 14, 18, 22, 26]
+    for i in diag_idx:
+        ibound[i, i] = 1
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        par_info = pyemu.pp_utils.setup_pilotpoints_grid(
+            sr=sr,
+            ibound=ibound,
+            prefix_dict={0: "hk1_"},
+            every_n_cell=4,
+            pp_dir=tmp_path,
+            tpl_dir=tmp_path,
+            shapename=None,
+        )
+        assert len(par_info) == len(diag_idx)
+        msgs = [str(wi.message) for wi in w if issubclass(wi.category, PyemuWarning)]
+        assert any(
+            "implies up to" in m and "were found" in m for m in msgs
+        ), f"expected an under-delivery PyemuWarning, got: {msgs}"
+
+
+def test_setup_pp_uneven_coverage_triggers_fallback(tmp_path):
+    """A zone made of two disjoint diagonal segments can clear
+    MIN_KRIGE_PPOINTS via the direct stride search while still being badly
+    covered - e.g. if the search's fixed candidate grid happens to
+    "phase-align" with only one of the two segments, every direct hit
+    comes from that one segment and the other is left with none, even
+    though the zone has plenty of active cells overall. The fallback
+    should trigger on this under-delivery (not just on too-few hits) so
+    both segments end up represented.
+    """
+    import numpy as np
+    import pyemu
+
+    nrow, ncol = 30, 30
+    sr = pyemu.helpers.SpatialReference(
+        delr=[100.0] * ncol,
+        delc=[100.0] * nrow,
+        rotation=0,
+        epsg=3070,
+        xul=0.0,
+        yul=0.0,
+        units="meters",
+        lenuni=2,
+    )
+    ibound = np.zeros((nrow, ncol), dtype=int)
+    # two parallel diagonal segments (rows 0-14 and 15-29) - the
+    # every_n_cell=4 stride's fixed candidate grid only phase-aligns with
+    # the lower segment, so the direct search finds 3 points there and
+    # none at all in the upper segment
+    for k in range(nrow):
+        ibound[k, (k * 2) % ncol] = 1
+
+    par_info = pyemu.pp_utils.setup_pilotpoints_grid(
+        sr=sr,
+        ibound=ibound,
+        prefix_dict={0: "hk1_"},
+        every_n_cell=4,
+        pp_dir=tmp_path,
+        tpl_dir=tmp_path,
+        shapename=None,
+    )
+    assert par_info["i"].min() < 15, (
+        "no pilot points fell in the upper diagonal segment (rows < 15) - "
+        "coverage is still lopsided"
+    )
+    assert par_info["i"].max() >= 15, (
+        "no pilot points fell in the lower diagonal segment (rows >= 15)"
+    )
+
+
+def test_setup_pp_dense_fallback_is_capped(tmp_path):
+    """A large zone whose active cells all "alias" against the
+    every_n_cell stride (so none of the candidate locations land on an
+    active cell) forces the dense fallback of pp_utils.py, which used to
+    take every single active cell unconditionally. That should be capped
+    back down towards what every_n_cell nominally requested, rather than
+    exploding into one pilot point per active cell.
+    """
+    import numpy as np
+    import pyemu
+
+    nrow, ncol = 400, 400
+    sr = pyemu.helpers.SpatialReference(
+        delr=[100.0] * ncol,
+        delc=[100.0] * nrow,
+        rotation=0,
+        epsg=3070,
+        xul=0.0,
+        yul=0.0,
+        units="meters",
+        lenuni=2,
+    )
+    ibound = np.zeros((nrow, ncol), dtype=int)
+    # dense vertical line at col=200, active on 3 of every 4 rows (skips
+    # the residue class that the every_n_cell=4 stride samples), so every
+    # row-candidate check misses and the fallback is forced with a large
+    # (299-cell) active set
+    col = 200
+    for i in range(1, 399):
+        if i % 4 != 3:
+            ibound[i, col] = 1
+    n_active = int((ibound > 0).sum())
+    assert n_active == 299
+
+    par_info = pyemu.pp_utils.setup_pilotpoints_grid(
+        sr=sr,
+        ibound=ibound,
+        prefix_dict={0: "hk1_"},
+        every_n_cell=4,
+        pp_dir=tmp_path,
+        tpl_dir=tmp_path,
+        shapename=None,
+    )
+    assert pyemu.pp_utils.MIN_KRIGE_PPOINTS <= len(par_info) < n_active, (
+        f"expected the fallback to be capped well below the {n_active} active "
+        f"cells, got {len(par_info)} pilot points"
+    )
+
+
 def read_hob_test(tmp_path):
     import os
     import pyemu

--- a/autotest/utils_tests.py
+++ b/autotest/utils_tests.py
@@ -748,6 +748,152 @@ def test_setup_pp_dense_fallback_is_capped(tmp_path):
     )
 
 
+def test_setup_pp_xsection_single_row(tmp_path):
+    """Regression test for the old, removed 'fix for x-section models'
+    special case (develop's pp_utils.py: `if xcentergrid.shape[0] == 1:
+    start_row = 0`), which existed so a cross-sectional model - a grid
+    that is a single row - doesn't have its only row skipped by the
+    every_n_cell stride offset.
+
+    The current per-zone bounding-box logic folds this into the general
+    "zone thinner than one stride step" branch (pp_utils.py: `if h_row <=
+    every_n_cell: row_cands = [row_min + h_row // 2]`) - since a single-row
+    grid always has h_row == 1, this should always resolve to row 0. This
+    test exercises that with a partially-active row (not all cells active),
+    so it's not trivially satisfied by there being only one candidate row
+    to begin with.
+    """
+    import numpy as np
+    import pyemu
+
+    nrow, ncol = 1, 50
+    sr = pyemu.helpers.SpatialReference(
+        delr=[100.0] * ncol,
+        delc=[100.0] * nrow,
+        rotation=0,
+        epsg=3070,
+        xul=0.0,
+        yul=0.0,
+        units="meters",
+        lenuni=2,
+    )
+    ibound = np.zeros((nrow, ncol), dtype=int)
+    ibound[0, 10:41] = 1  # active cells 10-40, inactive elsewhere
+
+    par_info = pyemu.pp_utils.setup_pilotpoints_grid(
+        sr=sr,
+        ibound=ibound,
+        prefix_dict={0: "hk1_"},
+        every_n_cell=4,
+        pp_dir=tmp_path,
+        tpl_dir=tmp_path,
+        shapename=None,
+    )
+    assert not par_info.empty, (
+        "no pilot points were generated for a single-row (x-section) grid "
+        "with an active row"
+    )
+    assert (par_info.i.astype(int) == 0).all(), (
+        f"expected all pilot points on row 0 for a single-row grid, got "
+        f"rows {sorted(par_info.i.unique())}"
+    )
+    js = sorted(par_info.j.astype(int))
+    assert js[0] >= 10 and js[-1] <= 40, (
+        f"pilot points should fall within the active column range "
+        f"[10, 40], got {js}"
+    )
+    assert len(par_info) >= pyemu.pp_utils.MIN_KRIGE_PPOINTS
+
+
+def test_setup_pp_xsection_single_col(tmp_path):
+    """Mirror of test_setup_pp_xsection_single_row for the
+    `xcentergrid.shape[1] == 1` (single-column) x-section case."""
+    import numpy as np
+    import pyemu
+
+    nrow, ncol = 50, 1
+    sr = pyemu.helpers.SpatialReference(
+        delr=[100.0] * ncol,
+        delc=[100.0] * nrow,
+        rotation=0,
+        epsg=3070,
+        xul=0.0,
+        yul=0.0,
+        units="meters",
+        lenuni=2,
+    )
+    ibound = np.zeros((nrow, ncol), dtype=int)
+    ibound[10:41, 0] = 1  # active cells 10-40, inactive elsewhere
+
+    par_info = pyemu.pp_utils.setup_pilotpoints_grid(
+        sr=sr,
+        ibound=ibound,
+        prefix_dict={0: "hk1_"},
+        every_n_cell=4,
+        pp_dir=tmp_path,
+        tpl_dir=tmp_path,
+        shapename=None,
+    )
+    assert not par_info.empty, (
+        "no pilot points were generated for a single-column (x-section) "
+        "grid with an active column"
+    )
+    assert (par_info.j.astype(int) == 0).all(), (
+        f"expected all pilot points on col 0 for a single-column grid, got "
+        f"cols {sorted(par_info.j.unique())}"
+    )
+    is_ = sorted(par_info.i.astype(int))
+    assert is_[0] >= 10 and is_[-1] <= 40, (
+        f"pilot points should fall within the active row range "
+        f"[10, 40], got {is_}"
+    )
+    assert len(par_info) >= pyemu.pp_utils.MIN_KRIGE_PPOINTS
+
+
+def test_setup_pp_xsection_multi_zone(tmp_path):
+    """x-section (single-row) grid with two distinct ibound zones along
+    the row, to confirm the per-zone bounding-box anchoring doesn't break
+    down when there's more than one zone sharing the degenerate axis."""
+    import numpy as np
+    import pyemu
+
+    nrow, ncol = 1, 60
+    sr = pyemu.helpers.SpatialReference(
+        delr=[100.0] * ncol,
+        delc=[100.0] * nrow,
+        rotation=0,
+        epsg=3070,
+        xul=0.0,
+        yul=0.0,
+        units="meters",
+        lenuni=2,
+    )
+    ibound = np.zeros((nrow, ncol), dtype=int)
+    ibound[0, 5:25] = 1
+    ibound[0, 35:55] = 2
+
+    par_info = pyemu.pp_utils.setup_pilotpoints_grid(
+        sr=sr,
+        ibound=ibound,
+        prefix_dict={0: "hk1_"},
+        every_n_cell=4,
+        use_ibound_zones=True,
+        pp_dir=tmp_path,
+        tpl_dir=tmp_path,
+        shapename=None,
+    )
+    assert not par_info.empty
+    assert (par_info.i.astype(int) == 0).all()
+    zones_hit = set(par_info.zone.astype(int).unique())
+    assert zones_hit == {1, 2}, f"expected pilot points in both zones, got {zones_hit}"
+    for zone, (lo, hi) in {1: (5, 24), 2: (35, 54)}.items():
+        js = sorted(par_info.loc[par_info.zone.astype(int) == zone, "j"].astype(int))
+        assert js[0] >= lo and js[-1] <= hi, (
+            f"zone {zone} pilot points should fall within [{lo}, {hi}], got {js}"
+        )
+        assert len(js) >= pyemu.pp_utils.MIN_KRIGE_PPOINTS
+
+
 def read_hob_test(tmp_path):
     import os
     import pyemu

--- a/pyemu/utils/pp_utils.py
+++ b/pyemu/utils/pp_utils.py
@@ -24,6 +24,17 @@ PP_FMT = {
 }
 PP_NAMES = ["name", "x", "y", "zone", "parval1"]
 
+# ordinary kriging needs at least 3 non-collinear points to avoid a
+# singular system - fewer than this and interpolation is not well-posed
+MIN_KRIGE_PPOINTS = 3
+
+# only flag the search as having "under-delivered" relative to what
+# every_n_cell nominally requested for a zone's bounding box if the
+# shortfall is large - a modest shortfall is expected any time a zone's
+# shape doesn't fill its own bounding box (e.g. a diagonal or L-shaped
+# zone) and isn't by itself a sign that interpolation will be poor
+PPOINT_UNDER_DELIVERY_FRACTION = 0.5
+
 
 def setup_pilotpoints_grid(
     ml=None,
@@ -137,17 +148,6 @@ def setup_pilotpoints_grid(
             ycentergrid = np.reshape(ycentergrid, (ycentergrid.shape[0], 1))
 
 
-    # fix for x-section models
-    if xcentergrid.shape[0] == 1:
-        start_row = 0
-    else:
-        start_row = start
-
-    if xcentergrid.shape[1] == 1:
-        start_col = 0
-    else:
-        start_col = start
-
     # check prefix_dict
     keys = list(prefix_dict.keys())
     keys.sort()
@@ -215,23 +215,152 @@ def setup_pilotpoints_grid(
                         pp_df.append([name, x, y, zone, parval1, k,])
                         pp_count += 1
             else:
-                # cycle through rows and cols
-                # allow to run closer to outside edge rather than leaving a gap
-                for i in range(start_row, ib.shape[0] - start_row//2, every_n_cell):
-                    for j in range(start_col, ib.shape[1] - start_col//2, every_n_cell):
-                        # skip if this is an inactive cell
-                        if ib[i, j] <= 0:  # this will account for MF6 style ibound as well
-                            continue
-                        # get the attributes we need
+                # cycle through zones, searching within each zone's own
+                # extent rather than the full array - this way a zone
+                # whose active cells never line up with a stride anchored
+                # to the full grid still gets sampled (this accounts for
+                # MF6-style ibound too, since only >0 cells are active)
+                if use_ibound_zones:
+                    zone_vals = sorted(z for z in np.unique(ib) if z > 0)
+                else:
+                    zone_vals = [1] if np.any(ib > 0) else []
+
+                for zone in zone_vals:
+                    zone_mask = (ib == zone) if use_ibound_zones else (ib > 0)
+                    rows, cols = np.where(zone_mask)
+                    row_min, row_max = int(rows.min()), int(rows.max())
+                    col_min, col_max = int(cols.min()), int(cols.max())
+                    h_row = row_max - row_min + 1
+                    h_col = col_max - col_min + 1
+
+                    # if the zone is thinner than a single stride step along
+                    # an axis (this also covers x-section models, where the
+                    # whole array is a single row or column), just use the
+                    # midpoint of that axis instead of striding it
+                    if h_row <= every_n_cell:
+                        row_cands = [row_min + h_row // 2]
+                    else:
+                        # allow to run closer to outside edge rather than
+                        # leaving a gap
+                        row_cands = list(range(
+                            row_min + start, row_min + h_row - start // 2, every_n_cell
+                        ))
+                    if h_col <= every_n_cell:
+                        col_cands = [col_min + h_col // 2]
+                    else:
+                        col_cands = list(range(
+                            col_min + start, col_min + h_col - start // 2, every_n_cell
+                        ))
+
+                    n_requested = len(row_cands) * len(col_cands)
+                    hits = [
+                        (i, j) for i in row_cands for j in col_cands if zone_mask[i, j]
+                    ]
+                    fallback_threshold = max(
+                        MIN_KRIGE_PPOINTS, n_requested * PPOINT_UNDER_DELIVERY_FRACTION
+                    )
+                    if len(hits) < fallback_threshold:
+                        # too few of the candidate stride locations landed
+                        # on an active cell - either below the hard floor,
+                        # or well below what every_n_cell requested for
+                        # this zone (e.g. a small, irregular/non-
+                        # rectangular, periodic, or multi-part zone shape
+                        # that "aliases" against the stride, so the direct
+                        # hits it does find are few and/or clustered in
+                        # only part of the zone) - fall back to using the
+                        # zone's active cells directly so a zone that
+                        # actually has enough active cells to support
+                        # kriging - spread across its whole extent - isn't
+                        # raised on, or left with lopsided coverage, just
+                        # because the coarse stride under-sampled it.
+                        # Decimated back down towards what was actually
+                        # requested so a large zone that aliases against
+                        # the stride doesn't explode into a pilot point for
+                        # every single active cell. Never decimate below
+                        # MIN_KRIGE_PPOINTS purely because the zone's own
+                        # bbox-implied request was small.
+                        n_direct = len(hits)
+                        all_hits = list(zip(rows.tolist(), cols.tolist()))
+                        target = max(n_requested, MIN_KRIGE_PPOINTS)
+                        if len(all_hits) > target:
+                            # bucket the zone's bounding box into a grid
+                            # sized (and shaped) to the zone's own aspect
+                            # ratio, and take one active cell per occupied
+                            # bucket - this spreads the decimated points
+                            # across both axes instead of streaking
+                            # through np.where's row-major cell order, and
+                            # (by sizing the two axes to h_row/h_col rather
+                            # than a flat sqrt(target) x sqrt(target) grid)
+                            # still spreads properly along a long, thin
+                            # zone rather than collapsing its short axis
+                            # size the "minor" (relatively shorter) axis
+                            # first and clamp it to >=1, then derive the
+                            # other axis from the target/minor ratio - this
+                            # keeps row_buckets * col_buckets close to
+                            # target even when one axis is so short (e.g. a
+                            # single-column zone) that its raw sqrt-based
+                            # share would round below 1
+                            all_arr = np.array(all_hits)
+                            raw_row = (target * h_row / h_col) ** 0.5
+                            raw_col = (target * h_col / h_row) ** 0.5
+                            if raw_row <= raw_col:
+                                row_buckets = max(1, round(raw_row))
+                                col_buckets = max(1, round(target / row_buckets))
+                            else:
+                                col_buckets = max(1, round(raw_col))
+                                row_buckets = max(1, round(target / col_buckets))
+                            row_bins = np.linspace(row_min, row_max + 1, row_buckets + 1)
+                            col_bins = np.linspace(col_min, col_max + 1, col_buckets + 1)
+                            row_bucket = np.clip(
+                                np.digitize(all_arr[:, 0], row_bins) - 1, 0, row_buckets - 1
+                            )
+                            col_bucket = np.clip(
+                                np.digitize(all_arr[:, 1], col_bins) - 1, 0, col_buckets - 1
+                            )
+                            bucket_id = row_bucket * col_buckets + col_bucket
+                            _, first_idx = np.unique(bucket_id, return_index=True)
+                            hits = [all_hits[i] for i in sorted(first_idx.tolist())]
+                        else:
+                            hits = all_hits
+                        warnings.warn(
+                            "setup_pilotpoints_grid(): layer {0}, zone {1}: the "
+                            "every_n_cell={2} stride search found only {3} of {4} "
+                            "requested candidate location(s) for this zone - falling "
+                            "back to using its {5} active cell(s) directly, giving {6} "
+                            "pilot point(s).".format(
+                                k, zone, every_n_cell, n_direct, n_requested, len(rows), len(hits)
+                            ),
+                            PyemuWarning,
+                        )
+
+                    if len(hits) < MIN_KRIGE_PPOINTS:
+                        raise Exception(
+                            "setup_pilotpoints_grid(): layer {0}, zone {1} produced only "
+                            "{2} pilot point(s) ({3} active cell(s) in this zone) - fewer "
+                            "than the {4} needed for ordinary kriging to be well-posed. "
+                            "Merge this zone with a neighboring one, lower every_n_cell, "
+                            "or exclude this zone/layer from the pilot point "
+                            "parameterization.".format(
+                                k, zone, len(hits), len(rows), MIN_KRIGE_PPOINTS
+                            )
+                        )
+                    elif len(hits) < n_requested * PPOINT_UNDER_DELIVERY_FRACTION:
+                        warnings.warn(
+                            "setup_pilotpoints_grid(): layer {0}, zone {1}: every_n_cell={2} "
+                            "implies up to {3} pilot point location(s) for this zone's "
+                            "extent, but only {4} were found ({5} active cell(s)) - check "
+                            "the zone's shape, or consider a smaller every_n_cell for "
+                            "better coverage.".format(
+                                k, zone, every_n_cell, n_requested, len(hits), len(rows)
+                            ),
+                            PyemuWarning,
+                        )
+
+                    for i, j in hits:
                         x = xcentergrid[i, j]
                         y = ycentergrid[i, j]
                         name = "pp_{0:04d}".format(pp_count)
                         parval1 = 1.0
-
-                        # decide what to use as the zone
-                        zone = 1
-                        if use_ibound_zones:
-                            zone = ib[i, j]
                         # stick this pilot point into a dataframe container
                         pp_df.append([name, x, y, zone, parval1, k, i, j])
                         pp_count += 1


### PR DESCRIPTION
## Summary

`pyemu.pp_utils.setup_pilotpoints_grid()`'s structured-grid search anchored its `every_n_cell` stride to the **full ibound/zone array shape**, rather than to each zone individually. As a result, a zone whose active cells didn't happen to line up with that fixed, globally-anchored grid could be silently skipped entirely — even though the zone had plenty of valid (`>0`) cells. When this happened for every layer/prefix in a call, `par_info` (built up as a list) stayed empty and:

```python
par_info = pd.concat(par_info)   # pp_utils.py
```

raised an opaque `ValueError: No objects to concatenate`, with no indication that the real cause was a zone geometry / stride mismatch.

This PR reworks the structured-grid search to anchor per-zone instead of per-array, adds a shape-aware fallback for zones the direct search still misses or covers unevenly, and adds explicit validation (a hard floor + warnings) around how many pilot points a zone actually ends up with, since "how many points is enough to support kriging" was previously never checked at all.

## Root cause

- `pp_utils.py`'s row/col search loop (`for i in range(start_row, ib.shape[0] - start_row//2, every_n_cell): ...`) computed its stride start/stop purely from the **array's** shape, so a zone confined to (or shaped within) a sub-region of that array had no guarantee any candidate location would land on one of its cells.
- This could manifest as:
  - A zone entirely missed (zero pilot points), cascading to the `pd.concat([])` crash if it happened for every layer/zone.
  - A zone with only *some* of its area sampled (uneven coverage) if the stride "phase-aliased" against only part of a multi-part/periodic zone shape (e.g. two parallel diagonal segments only one of which lined up with the stride).
  - A zone thinner than one stride step along an axis getting reduced to a single midpoint candidate, which could itself fail to land on an active cell, or which cleared the search but not with enough points for meaningful kriging.
- Separately, there was no check anywhere in the pipeline for whether a zone ended up with **enough** pilot points to support kriging at all (ordinary kriging is only meaningful with several points, not 1-2).

## Fix

In `pyemu/utils/pp_utils.py`, the structured-grid branch of `setup_pilotpoints_grid()` now:

1. **Anchors the stride per zone.** For each zone (each unique `ibound` value when `use_ibound_zones=True`, or the single "all active cells" group otherwise), the search computes the zone's own bounding box and anchors the `every_n_cell` stride to it, rather than to the full array. This is mathematically identical to the old behavior whenever a zone's bbox equals the full array (the common case — verified against all pre-existing tests).
2. **Handles thin zones.** If a zone's extent along an axis is `<= every_n_cell`, that axis just uses its midpoint instead of striding (this also subsumes the old, separate x-section-model special case).
3. **Falls back when the direct search under-delivers**, not just when it finds zero candidates. The trigger is `len(hits) < max(MIN_KRIGE_PPOINTS, n_requested * PPOINT_UNDER_DELIVERY_FRACTION)` — i.e. either below the hard floor, or well below what `every_n_cell` nominally requested for that zone. This catches both "zone entirely missed" and "zone unevenly covered" (e.g. only one part of a multi-segment zone got sampled even though the total hit count looked acceptable).
4. **Fallback uses the zone's real active-cell set**, decimated back down via an aspect-ratio-aware 2D bucketing (not a flat `sqrt(target) x sqrt(target)` grid, which breaks for elongated/1D-like zones) so a large zone that aliases against the stride doesn't explode into one pilot point per active cell, while a small zone gets properly represented instead of raising unnecessarily.
5. **`MIN_KRIGE_PPOINTS = 3`** (the minimum for ordinary kriging to be well-posed) is now a hard floor: if even the fallback can't produce 3 points for a zone/layer, `setup_pilotpoints_grid()` raises a clear exception naming the zone/layer/active-cell-count, instead of the previous silent under-determined result (or the opaque `pd.concat([])` crash if this happened everywhere).
6. **New warnings** (`PyemuWarning`) fire when the fallback engages (reporting direct vs. requested vs. final counts) and when a zone still under-delivers relative to what was requested even after using every one of its active cells (i.e. the zone genuinely doesn't have enough active area, and nothing more can be done).

## Testing

Added to `autotest/utils_tests.py`:
- `test_setup_pp_misses_offgrid_active_zone` — reproduces the original bug (a zone whose active cells don't align with the global stride) and confirms it's no longer dropped.
- `test_setup_pp_too_few_points_raises` — a single-active-cell zone raises a clear exception instead of silently returning 1 point.
- `test_setup_pp_small_zone_uses_fallback_instead_of_raising` — a small (3x3) but not-too-small zone uses the fallback instead of raising.
- `test_setup_pp_under_delivery_warns` — a sparse zone that clears the floor but is far below the requested density warns rather than silently under-delivering.
- `test_setup_pp_dense_fallback_is_capped` — a large zone that fully aliases against the stride gets capped/decimated, not exploded into one point per active cell.
- `test_setup_pp_uneven_coverage_triggers_fallback` — a two-segment zone that clears the point-count floor via the direct search, but with all hits clustered in one segment, now gets coverage in both segments.

All pre-existing pilot-point tests (`test_setup_pp`, `test_ppu_geostats` in `utils_tests.py`; `shortname_conversion_test` and `test_hyperpars` — the one existing test exercising `use_pp_zones=True` — in `pst_from_tests.py`) continue to pass unchanged, confirming the fix is a no-op for the common case (verified the stride math reduces to exactly the old formula whenever a zone's bbox spans the full array).

Also added `autotest/investigate_pp_search_impact.py`, a standalone dev/investigation tool (not part of the pytest suite) comparing the pre-fix search against the current one across several synthetic and real-model (Freyberg) `ibound` scenarios, with a plot overlaying the zone raster and old-vs-new pilot point locations for each. This was used throughout development to validate the fix's impact and tune the warning thresholds, and is left in the repo in case it's useful for future work on this function.

## Test plan

- [x] `pytest autotest/utils_tests.py -k "test_setup_pp or test_ppu_geostats or test_setup_pp_misses_offgrid_active_zone or test_setup_pp_too_few_points_raises or test_setup_pp_small_zone_uses_fallback_instead_of_raising or test_setup_pp_under_delivery_warns or test_setup_pp_dense_fallback_is_capped or test_setup_pp_uneven_coverage_triggers_fallback"` — 8 passed
- [x] `pytest autotest/pst_from_tests.py -k "shortname_conversion_test or test_hyperpars"` — 2 passed
- [x] `python autotest/investigate_pp_search_impact.py` — no regressions against the real Freyberg model or the full-active-grid baseline case